### PR TITLE
feat: P0 Critical UX/UI Fixes

### DIFF
--- a/apps/web/app/dashboard/committee/page.tsx
+++ b/apps/web/app/dashboard/committee/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/queries/members';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { ErrorState, ListSkeleton } from '@/components/dashboard/states';
 
 const ME_QUERY = `
   query Me {
@@ -111,11 +112,25 @@ export default function CommitteePage() {
   };
 
   if (loading) {
-    return <div className="p-8">Loading committee...</div>;
+    return (
+      <div className="p-8 max-w-3xl mx-auto">
+        <div className="mb-8 space-y-2">
+          <div className="animate-pulse h-8 w-48 bg-muted rounded-lg" />
+          <div className="animate-pulse h-4 w-64 bg-muted rounded-lg" />
+        </div>
+        <ListSkeleton count={4} />
+      </div>
+    );
   }
 
   if (error) {
-    return <div className="p-8 text-destructive">{error}</div>;
+    return (
+      <ErrorState
+        title="Could not load committee"
+        message={error}
+        onRetry={() => window.location.reload()}
+      />
+    );
   }
 
   const admins = members.filter((m) => m.role === 'ADMIN');

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,52 +1,8 @@
 'use client';
 
-import { UserButton } from "@clerk/nextjs";
-import Link from "next/link";
 import { ReactNode } from "react";
+import { SidebarLayout } from "@/components/dashboard/Sidebar";
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
-  return (
-    <div className="min-h-screen bg-background">
-      <nav className="border-b border-border bg-background/80 backdrop-blur-lg sticky top-0 z-50">
-        <div className="container mx-auto px-4 h-16 flex items-center justify-between">
-          <div className="flex items-center gap-6">
-            <Link href="/dashboard" className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
-                <span className="text-primary-foreground font-bold text-sm">C</span>
-              </div>
-              <span className="text-xl font-bold">Condo Agora</span>
-            </Link>
-            <div className="hidden md:flex items-center gap-4">
-              <Link
-                href="/dashboard"
-                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Dashboard
-              </Link>
-              <Link
-                href="/dashboard/properties"
-                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Properties
-              </Link>
-              <Link
-                href="/dashboard/committee"
-                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Committee
-              </Link>
-              <Link
-                href="/dashboard/settings"
-                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Settings
-              </Link>
-            </div>
-          </div>
-          <UserButton />
-        </div>
-      </nav>
-      <main>{children}</main>
-    </div>
-  );
+  return <SidebarLayout>{children}</SidebarLayout>;
 }

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,31 +1,408 @@
 'use client';
 
-import { useUser } from "@clerk/nextjs";
-import Link from "next/link";
+import { useState, useEffect, useCallback } from 'react';
+import { useUser } from '@clerk/nextjs';
+import Link from 'next/link';
+import { useAuthToken } from '@/hooks/use-auth-token';
+import { getApiClient } from '@/lib/api';
+import { GET_HOUSES, type House, type GetHousesResponse } from '@/lib/queries/house';
+import {
+  GET_ORGANIZATION_MEMBERS,
+  type Member,
+  type GetMembersResponse,
+} from '@/lib/queries/members';
+import { StatCardsSkeleton } from '@/components/dashboard/states';
+import { ErrorState } from '@/components/dashboard/states';
+import {
+  Building2,
+  Users,
+  Mail,
+  Lightbulb,
+  Plus,
+  UserPlus,
+  ArrowRight,
+  CheckCircle2,
+  Circle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const ME_QUERY = `
+  query Me {
+    me {
+      id
+      memberships {
+        organization { id, name }
+        role
+      }
+    }
+  }
+`;
+
+type MeResponse = {
+  me: {
+    id: string;
+    memberships: { organization: { id: string; name: string }; role: string }[];
+  } | null;
+};
+
+type DashboardData = {
+  organizationName: string;
+  isAdmin: boolean;
+  houses: House[];
+  members: Member[];
+};
 
 export default function DashboardPage() {
   const { user } = useUser();
+  const { getAuthToken } = useAuthToken();
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDashboard = useCallback(async () => {
+    try {
+      const token = await getAuthToken();
+      const client = getApiClient(token);
+      const meData = await client.request<MeResponse>(ME_QUERY);
+
+      if (!meData.me || meData.me.memberships.length === 0) {
+        setData({
+          organizationName: '',
+          isAdmin: false,
+          houses: [],
+          members: [],
+        });
+        setLoading(false);
+        return;
+      }
+
+      const membership = meData.me.memberships[0];
+      const orgId = membership.organization.id;
+
+      const [housesData, membersData] = await Promise.all([
+        client.request<GetHousesResponse>(GET_HOUSES, { organizationId: orgId }),
+        client.request<GetMembersResponse>(GET_ORGANIZATION_MEMBERS, {
+          organizationId: orgId,
+        }),
+      ]);
+
+      setData({
+        organizationName: membership.organization.name,
+        isAdmin: membership.role === 'ADMIN',
+        houses: housesData.houses,
+        members: membersData.organizationMembers,
+      });
+    } catch (err) {
+      console.error('Failed to load dashboard:', err);
+      setError('Failed to load dashboard data.');
+    } finally {
+      setLoading(false);
+    }
+  }, [getAuthToken]);
+
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  if (loading) {
+    return (
+      <div className="p-6 lg:p-8 max-w-6xl mx-auto space-y-8">
+        <div className="space-y-2">
+          <div className="animate-pulse h-8 w-64 bg-muted rounded-lg" />
+          <div className="animate-pulse h-4 w-80 bg-muted rounded-lg" />
+        </div>
+        <StatCardsSkeleton count={4} />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 space-y-4">
+            <div className="animate-pulse h-64 bg-muted rounded-xl" />
+          </div>
+          <div className="animate-pulse h-64 bg-muted rounded-xl" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <ErrorState
+        title="Could not load dashboard"
+        message={error}
+        onRetry={() => window.location.reload()}
+      />
+    );
+  }
+
+  const totalProperties = data?.houses.length ?? 0;
+  const totalResidents = data?.members.length ?? 0;
+  const totalAdmins = data?.members.filter((m) => m.role === 'ADMIN').length ?? 0;
+  const unassignedMembers =
+    data?.members.filter((m) => !m.houseId).length ?? 0;
+
+  // Onboarding checklist
+  const hasOrg = !!data?.organizationName;
+  const hasProperty = totalProperties > 0;
+  const hasMembers = totalResidents > 1; // more than just the admin
+  const onboardingComplete = hasOrg && hasProperty && hasMembers;
+  const onboardingSteps = [
+    {
+      label: 'Join or create an organization',
+      done: hasOrg,
+      href: '/onboarding',
+    },
+    {
+      label: 'Add your first property',
+      done: hasProperty,
+      href: '/dashboard/properties',
+    },
+    {
+      label: 'Invite your first resident',
+      done: hasMembers,
+      href: '/dashboard/settings',
+    },
+  ];
+
+  const stats = [
+    {
+      label: 'Properties',
+      value: totalProperties,
+      icon: Building2,
+      href: '/dashboard/properties',
+      color: 'text-blue-600 bg-blue-100',
+    },
+    {
+      label: 'Members',
+      value: totalResidents,
+      icon: Users,
+      href: '/dashboard/committee',
+      color: 'text-emerald-600 bg-emerald-100',
+    },
+    {
+      label: 'Board Members',
+      value: totalAdmins,
+      icon: Mail,
+      href: '/dashboard/committee',
+      color: 'text-amber-600 bg-amber-100',
+    },
+    {
+      label: 'Unassigned',
+      value: unassignedMembers,
+      icon: Lightbulb,
+      href: '/dashboard/committee',
+      color: 'text-purple-600 bg-purple-100',
+    },
+  ];
 
   return (
-    <div className="p-8">
-      <h1 className="text-3xl font-bold mb-4">Welcome, {user?.firstName || "User"}!</h1>
-      <p className="text-muted-foreground mb-8">
-        This is your dashboard. From here you can manage your condo resources.
-      </p>
-      
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <Link href="/dashboard/properties" className="block p-6 border rounded-lg hover:border-primary transition-colors">
-          <h2 className="text-xl font-semibold mb-2">Properties</h2>
-          <p className="text-sm text-muted-foreground">Manage houses and units in your community.</p>
-        </Link>
-        <Link href="/dashboard/committee" className="block p-6 border rounded-lg hover:border-primary transition-colors">
-          <h2 className="text-xl font-semibold mb-2">Committee</h2>
-          <p className="text-sm text-muted-foreground">View board members and manage roles.</p>
-        </Link>
-        <Link href="/dashboard/settings" className="block p-6 border rounded-lg hover:border-primary transition-colors">
-          <h2 className="text-xl font-semibold mb-2">Settings</h2>
-          <p className="text-sm text-muted-foreground">Invite users and manage your profile.</p>
-        </Link>
+    <div className="p-6 lg:p-8 max-w-6xl mx-auto space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl lg:text-3xl font-bold">
+          Welcome back, {user?.firstName || 'User'}!
+        </h1>
+        {data?.organizationName && (
+          <p className="text-muted-foreground mt-1">
+            {data.organizationName} &middot; Overview
+          </p>
+        )}
+      </div>
+
+      {/* Stat Cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {stats.map((stat) => {
+          const Icon = stat.icon;
+          return (
+            <Link
+              key={stat.label}
+              href={stat.href}
+              className="group border rounded-xl p-5 hover:border-primary/30 hover:shadow-md transition-all duration-200"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-sm text-muted-foreground">{stat.label}</span>
+                <div
+                  className={`w-9 h-9 rounded-lg flex items-center justify-center ${stat.color}`}
+                >
+                  <Icon size={18} />
+                </div>
+              </div>
+              <p className="text-2xl font-bold">{stat.value}</p>
+              <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1 group-hover:text-primary transition-colors">
+                View details <ArrowRight size={12} />
+              </p>
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Main content grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left column - Quick Actions + Recent Members */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Quick Actions */}
+          {data?.isAdmin && (
+            <div className="border rounded-xl p-6">
+              <h2 className="text-lg font-semibold mb-4">Quick Actions</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <Button variant="outline" className="justify-start h-auto py-3" asChild>
+                  <Link href="/dashboard/properties">
+                    <Plus size={16} className="mr-2 text-primary" />
+                    Add Property
+                  </Link>
+                </Button>
+                <Button variant="outline" className="justify-start h-auto py-3" asChild>
+                  <Link href="/dashboard/settings">
+                    <UserPlus size={16} className="mr-2 text-primary" />
+                    Invite Member
+                  </Link>
+                </Button>
+                <Button variant="outline" className="justify-start h-auto py-3" asChild>
+                  <Link href="/dashboard/committee">
+                    <Users size={16} className="mr-2 text-primary" />
+                    Manage Committee
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Recent Members */}
+          <div className="border rounded-xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">Recent Members</h2>
+              <Button variant="ghost" size="sm" asChild>
+                <Link href="/dashboard/committee">
+                  View all <ArrowRight size={14} className="ml-1" />
+                </Link>
+              </Button>
+            </div>
+
+            {data?.members && data.members.length > 0 ? (
+              <div className="space-y-3">
+                {data.members.slice(0, 5).map((member) => {
+                  const name =
+                    member.firstName || member.lastName
+                      ? [member.firstName, member.lastName].filter(Boolean).join(' ')
+                      : member.email;
+                  return (
+                    <div
+                      key={member.id}
+                      className="flex items-center justify-between py-2"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                          <span className="text-xs font-semibold text-primary">
+                            {(member.firstName?.[0] || member.email[0]).toUpperCase()}
+                          </span>
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium truncate">{name}</p>
+                          <p className="text-xs text-muted-foreground truncate">
+                            {member.houseName
+                              ? `Unit: ${member.houseName}`
+                              : 'No unit assigned'}
+                          </p>
+                        </div>
+                      </div>
+                      <span
+                        className={`text-xs px-2 py-1 rounded-full shrink-0 ${
+                          member.role === 'ADMIN'
+                            ? 'bg-primary/10 text-primary'
+                            : 'bg-muted text-muted-foreground'
+                        }`}
+                      >
+                        {member.role}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No members yet. Invite your first team member to get started.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Right column - Onboarding + Properties */}
+        <div className="space-y-6">
+          {/* Onboarding Checklist - only show if incomplete */}
+          {!onboardingComplete && (
+            <div className="border rounded-xl p-6 bg-primary/5 border-primary/20">
+              <h2 className="text-lg font-semibold mb-1">Getting Started</h2>
+              <p className="text-sm text-muted-foreground mb-4">
+                Complete these steps to set up your community.
+              </p>
+
+              {/* Progress bar */}
+              <div className="w-full h-2 bg-muted rounded-full mb-4 overflow-hidden">
+                <div
+                  className="h-full bg-primary rounded-full transition-all duration-500"
+                  style={{
+                    width: `${(onboardingSteps.filter((s) => s.done).length / onboardingSteps.length) * 100}%`,
+                  }}
+                />
+              </div>
+
+              <div className="space-y-3">
+                {onboardingSteps.map((step) => (
+                  <Link
+                    key={step.label}
+                    href={step.href}
+                    className={`flex items-center gap-3 text-sm py-1 transition-colors ${
+                      step.done
+                        ? 'text-muted-foreground line-through'
+                        : 'text-foreground hover:text-primary'
+                    }`}
+                  >
+                    {step.done ? (
+                      <CheckCircle2 size={18} className="text-emerald-500 shrink-0" />
+                    ) : (
+                      <Circle size={18} className="text-muted-foreground shrink-0" />
+                    )}
+                    {step.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Properties Summary */}
+          <div className="border rounded-xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">Properties</h2>
+              <Button variant="ghost" size="sm" asChild>
+                <Link href="/dashboard/properties">
+                  View all <ArrowRight size={14} className="ml-1" />
+                </Link>
+              </Button>
+            </div>
+
+            {data?.houses && data.houses.length > 0 ? (
+              <div className="space-y-2">
+                {data.houses.slice(0, 5).map((house) => (
+                  <Link
+                    key={house.id}
+                    href={`/dashboard/properties/${house.id}`}
+                    className="flex items-center justify-between p-3 rounded-lg border hover:border-primary/30 transition-colors"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Building2 size={16} className="text-muted-foreground shrink-0" />
+                      <span className="text-sm font-medium truncate">{house.name}</span>
+                    </div>
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {house.residents.length}{' '}
+                      {house.residents.length === 1 ? 'resident' : 'residents'}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No properties yet. Add your first one!
+              </p>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/app/dashboard/properties/[id]/page.tsx
+++ b/apps/web/app/dashboard/properties/[id]/page.tsx
@@ -15,6 +15,8 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ErrorState } from '@/components/dashboard/states';
+import { ListSkeleton } from '@/components/dashboard/states';
 
 const ME_QUERY = `
   query Me {
@@ -111,17 +113,25 @@ export default function HouseDetailPage() {
   };
 
   if (loading) {
-    return <div className="p-8">Loading property...</div>;
+    return (
+      <div className="p-8 max-w-3xl mx-auto">
+        <div className="animate-pulse h-4 w-24 bg-muted rounded mb-6" />
+        <div className="border rounded-xl p-6 mb-6 space-y-3">
+          <div className="animate-pulse h-7 w-48 bg-muted rounded" />
+          <div className="animate-pulse h-4 w-32 bg-muted rounded" />
+        </div>
+        <ListSkeleton count={3} />
+      </div>
+    );
   }
 
   if (error || !house) {
     return (
-      <div className="p-8">
-        <p className="text-destructive mb-4">{error || 'Property not found.'}</p>
-        <Link href="/dashboard/properties" className="text-primary hover:underline">
-          Back to Properties
-        </Link>
-      </div>
+      <ErrorState
+        title="Property not found"
+        message={error || 'The property you are looking for does not exist.'}
+        onRetry={() => window.location.reload()}
+      />
     );
   }
 

--- a/apps/web/app/dashboard/properties/page.tsx
+++ b/apps/web/app/dashboard/properties/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/queries/house';
 import HouseList from '@/components/properties/HouseList';
 import CreateHouseDialog from '@/components/properties/CreateHouseDialog';
+import { ErrorState, PropertyGridSkeleton } from '@/components/dashboard/states';
 
 const ME_QUERY = `
   query Me {
@@ -136,11 +137,25 @@ export default function PropertiesPage() {
   };
 
   if (loading) {
-    return <div className="p-8">Loading properties...</div>;
+    return (
+      <div className="p-8 max-w-5xl mx-auto">
+        <div className="mb-8 space-y-2">
+          <div className="animate-pulse h-8 w-48 bg-muted rounded-lg" />
+          <div className="animate-pulse h-4 w-64 bg-muted rounded-lg" />
+        </div>
+        <PropertyGridSkeleton />
+      </div>
+    );
   }
 
   if (error) {
-    return <div className="p-8 text-destructive">{error}</div>;
+    return (
+      <ErrorState
+        title="Could not load properties"
+        message={error}
+        onRetry={() => window.location.reload()}
+      />
+    );
   }
 
   return (

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, FormEvent } from 'react';
 import { useAuthToken } from '@/hooks/use-auth-token';
 import { getApiClient } from '@/lib/api';
 import { Button } from '@/components/ui/button';
+import { ErrorState } from '@/components/dashboard/states';
 
 const ME_QUERY = `
   query Me {
@@ -121,11 +122,25 @@ export default function SettingsPage() {
   };
 
   if (loading) {
-    return <div className="p-8">Loading settings...</div>;
+    return (
+      <div className="p-8 max-w-2xl mx-auto">
+        <div className="animate-pulse h-8 w-48 bg-muted rounded-lg mb-8" />
+        <div className="space-y-4">
+          <div className="animate-pulse h-16 w-full bg-muted rounded-lg" />
+          <div className="animate-pulse h-64 w-full bg-muted rounded-xl" />
+        </div>
+      </div>
+    );
   }
 
   if (error) {
-    return <div className="p-8 text-red-500">{error}</div>;
+    return (
+      <ErrorState
+        title="Could not load settings"
+        message={error}
+        onRetry={() => window.location.reload()}
+      />
+    );
   }
 
   if (!user || user.memberships.length === 0) {

--- a/apps/web/components/dashboard/Sidebar.tsx
+++ b/apps/web/components/dashboard/Sidebar.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useState, createContext, useContext, ReactNode } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useUser } from '@clerk/nextjs';
+import { UserButton } from '@clerk/nextjs';
+import {
+  LayoutDashboard,
+  Building2,
+  Users,
+  Lightbulb,
+  Vote,
+  BarChart3,
+  Settings,
+  Menu,
+  X,
+  ChevronLeft,
+} from 'lucide-react';
+
+const navItems = [
+  { href: '/dashboard', label: 'Overview', icon: LayoutDashboard, exact: true },
+  { href: '/dashboard/properties', label: 'Properties', icon: Building2 },
+  { href: '/dashboard/committee', label: 'Committee', icon: Users },
+  { href: '/dashboard/proposals', label: 'Proposals', icon: Lightbulb, disabled: true },
+  { href: '/dashboard/voting', label: 'Voting', icon: Vote, disabled: true },
+  { href: '/dashboard/reports', label: 'Reports', icon: BarChart3, disabled: true },
+];
+
+const bottomNavItems = [
+  { href: '/dashboard/settings', label: 'Settings', icon: Settings },
+];
+
+const SidebarContext = createContext({ collapsed: false });
+
+export function useSidebar() {
+  return useContext(SidebarContext);
+}
+
+export function SidebarLayout({ children }: { children: ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <SidebarContext.Provider value={{ collapsed }}>
+      <div className="min-h-screen bg-background">
+        <SidebarNav collapsed={collapsed} setCollapsed={setCollapsed} />
+        <main
+          className={`pt-14 lg:pt-0 min-h-screen transition-all duration-300 ${
+            collapsed ? 'lg:pl-[68px]' : 'lg:pl-60'
+          }`}
+        >
+          {children}
+        </main>
+      </div>
+    </SidebarContext.Provider>
+  );
+}
+
+function SidebarNav({
+  collapsed,
+  setCollapsed,
+}: {
+  collapsed: boolean;
+  setCollapsed: (v: boolean) => void;
+}) {
+  const pathname = usePathname();
+  const { user } = useUser();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const isActive = (href: string, exact?: boolean) => {
+    if (exact) return pathname === href;
+    return pathname === href || pathname.startsWith(href + '/');
+  };
+
+  const sidebarContent = (
+    <div className="flex flex-col h-full">
+      {/* Logo */}
+      <div className="h-16 flex items-center justify-between px-4 border-b border-sidebar-border">
+        <Link href="/dashboard" className="flex items-center gap-2 min-w-0">
+          <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center shrink-0">
+            <span className="text-primary-foreground font-bold text-sm">C</span>
+          </div>
+          {!collapsed && (
+            <span className="text-lg font-bold truncate">Condo Agora</span>
+          )}
+        </Link>
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="hidden lg:flex items-center justify-center w-6 h-6 rounded-md hover:bg-sidebar-accent transition-colors text-muted-foreground"
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
+          <ChevronLeft
+            size={16}
+            className={`transition-transform duration-200 ${collapsed ? 'rotate-180' : ''}`}
+          />
+        </button>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 py-4 px-3 space-y-1 overflow-y-auto">
+        {navItems.map((item) => {
+          const active = isActive(item.href, item.exact);
+          const Icon = item.icon;
+
+          if (item.disabled) {
+            return (
+              <div
+                key={item.href}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-muted-foreground/50 cursor-not-allowed"
+                title="Coming soon"
+              >
+                <Icon size={20} className="shrink-0" />
+                {!collapsed && (
+                  <>
+                    <span className="text-sm">{item.label}</span>
+                    <span className="ml-auto text-[10px] bg-muted px-1.5 py-0.5 rounded-full">
+                      Soon
+                    </span>
+                  </>
+                )}
+              </div>
+            );
+          }
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={() => setMobileOpen(false)}
+              className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200 group relative ${
+                active
+                  ? 'bg-primary/10 text-primary font-semibold'
+                  : 'text-muted-foreground hover:bg-sidebar-accent hover:text-foreground'
+              }`}
+            >
+              {active && (
+                <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-5 bg-primary rounded-r-full" />
+              )}
+              <Icon size={20} className="shrink-0" />
+              {!collapsed && <span className="text-sm">{item.label}</span>}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Bottom section */}
+      <div className="border-t border-sidebar-border px-3 py-4 space-y-1">
+        {bottomNavItems.map((item) => {
+          const active = isActive(item.href);
+          const Icon = item.icon;
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={() => setMobileOpen(false)}
+              className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200 relative ${
+                active
+                  ? 'bg-primary/10 text-primary font-semibold'
+                  : 'text-muted-foreground hover:bg-sidebar-accent hover:text-foreground'
+              }`}
+            >
+              {active && (
+                <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-5 bg-primary rounded-r-full" />
+              )}
+              <Icon size={20} className="shrink-0" />
+              {!collapsed && <span className="text-sm">{item.label}</span>}
+            </Link>
+          );
+        })}
+
+        {/* User profile */}
+        <div className="flex items-center gap-3 px-3 py-3 mt-2 rounded-lg bg-sidebar-accent/50">
+          <UserButton
+            appearance={{
+              elements: { avatarBox: 'w-8 h-8' },
+            }}
+          />
+          {!collapsed && (
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium truncate">
+                {user?.firstName} {user?.lastName}
+              </p>
+              <p className="text-xs text-muted-foreground truncate">
+                {user?.primaryEmailAddress?.emailAddress}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Mobile header bar */}
+      <div className="lg:hidden fixed top-0 left-0 right-0 z-50 h-14 bg-background/80 backdrop-blur-lg border-b border-border flex items-center px-4">
+        <button
+          onClick={() => setMobileOpen(true)}
+          className="p-2 -ml-2 rounded-lg hover:bg-muted transition-colors"
+          aria-label="Open menu"
+        >
+          <Menu size={20} />
+        </button>
+        <Link href="/dashboard" className="flex items-center gap-2 ml-2">
+          <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center">
+            <span className="text-primary-foreground font-bold text-xs">C</span>
+          </div>
+          <span className="text-lg font-bold">Condo Agora</span>
+        </Link>
+      </div>
+
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <div
+          className="lg:hidden fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+          onClick={() => setMobileOpen(false)}
+        >
+          <div
+            className="w-72 h-full bg-sidebar-background border-r border-sidebar-border shadow-xl animate-in slide-in-from-left duration-300"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setMobileOpen(false)}
+              className="absolute top-4 right-4 p-1 rounded-lg hover:bg-muted transition-colors"
+              aria-label="Close menu"
+            >
+              <X size={18} />
+            </button>
+            {sidebarContent}
+          </div>
+        </div>
+      )}
+
+      {/* Desktop sidebar */}
+      <aside
+        className={`hidden lg:flex flex-col fixed top-0 left-0 h-screen bg-sidebar-background border-r border-sidebar-border z-40 transition-all duration-300 ${
+          collapsed ? 'w-[68px]' : 'w-60'
+        }`}
+      >
+        {sidebarContent}
+      </aside>
+    </>
+  );
+}
+
+export default SidebarNav;

--- a/apps/web/components/dashboard/states/EmptyState.tsx
+++ b/apps/web/components/dashboard/states/EmptyState.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { ReactNode } from 'react';
+import {
+  Building2,
+  Users,
+  Lightbulb,
+  FileText,
+  Inbox,
+  type LucideIcon,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const iconMap: Record<string, LucideIcon> = {
+  properties: Building2,
+  residents: Users,
+  proposals: Lightbulb,
+  documents: FileText,
+  default: Inbox,
+};
+
+type EmptyStateProps = {
+  icon?: string | LucideIcon;
+  title: string;
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  children?: ReactNode;
+};
+
+export default function EmptyState({
+  icon = 'default',
+  title,
+  message,
+  actionLabel,
+  onAction,
+  children,
+}: EmptyStateProps) {
+  const Icon =
+    typeof icon === 'string'
+      ? iconMap[icon] || iconMap.default
+      : icon;
+
+  return (
+    <div className="flex items-center justify-center py-16 px-4">
+      <div className="text-center max-w-sm">
+        {/* Illustration */}
+        <div className="mx-auto w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center mb-6">
+          <Icon size={36} className="text-primary" />
+        </div>
+
+        <h3 className="text-lg font-semibold mb-2">{title}</h3>
+        <p className="text-muted-foreground text-sm mb-6">{message}</p>
+
+        {actionLabel && onAction && (
+          <Button onClick={onAction}>{actionLabel}</Button>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/states/ErrorState.tsx
+++ b/apps/web/components/dashboard/states/ErrorState.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { AlertTriangle } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+type ErrorStateProps = {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+  showDashboardLink?: boolean;
+};
+
+export default function ErrorState({
+  title = 'Something went wrong',
+  message = 'We ran into an unexpected error. Please try again.',
+  onRetry,
+  showDashboardLink = true,
+}: ErrorStateProps) {
+  return (
+    <div className="flex items-center justify-center min-h-[60vh] px-4">
+      <div className="text-center max-w-md">
+        {/* Illustration */}
+        <div className="mx-auto w-24 h-24 rounded-full bg-destructive/10 flex items-center justify-center mb-6">
+          <AlertTriangle size={40} className="text-destructive" />
+        </div>
+
+        <h2 className="text-xl font-semibold mb-2">{title}</h2>
+        <p className="text-muted-foreground mb-6">{message}</p>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          {onRetry && (
+            <Button onClick={onRetry}>Try Again</Button>
+          )}
+          {showDashboardLink && (
+            <Button variant="outline" asChild>
+              <Link href="/dashboard">Go to Dashboard</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/states/LoadingState.tsx
+++ b/apps/web/components/dashboard/states/LoadingState.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+type SkeletonProps = {
+  className?: string;
+};
+
+function Skeleton({ className = '' }: SkeletonProps) {
+  return (
+    <div
+      className={`animate-pulse rounded-lg bg-muted ${className}`}
+    />
+  );
+}
+
+export function CardSkeleton() {
+  return (
+    <div className="border rounded-xl p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-8 w-8 rounded-full" />
+      </div>
+      <Skeleton className="h-8 w-20" />
+      <Skeleton className="h-3 w-32" />
+    </div>
+  );
+}
+
+export function StatCardsSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <CardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function ListItemSkeleton() {
+  return (
+    <div className="flex items-center justify-between p-4 border rounded-lg">
+      <div className="flex items-center gap-3 flex-1">
+        <Skeleton className="h-10 w-10 rounded-full" />
+        <div className="space-y-2 flex-1">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48" />
+        </div>
+      </div>
+      <Skeleton className="h-6 w-16 rounded-full" />
+    </div>
+  );
+}
+
+export function ListSkeleton({ count = 5 }: { count?: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <ListItemSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function PropertyCardSkeleton() {
+  return (
+    <div className="border rounded-xl p-6 space-y-3">
+      <div className="flex items-start justify-between">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-5 w-20 rounded-full" />
+      </div>
+      <div className="flex items-center justify-between pt-2">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-8 w-16" />
+      </div>
+    </div>
+  );
+}
+
+export function PropertyGridSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <PropertyCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function PageSkeleton() {
+  return (
+    <div className="p-8 max-w-5xl mx-auto space-y-8">
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+      <StatCardsSkeleton count={3} />
+      <ListSkeleton count={4} />
+    </div>
+  );
+}
+
+export default function LoadingState() {
+  return <PageSkeleton />;
+}

--- a/apps/web/components/dashboard/states/index.ts
+++ b/apps/web/components/dashboard/states/index.ts
@@ -1,0 +1,3 @@
+export { default as ErrorState } from './ErrorState';
+export { default as EmptyState } from './EmptyState';
+export { default as LoadingState, StatCardsSkeleton, ListSkeleton, PropertyGridSkeleton, PageSkeleton, CardSkeleton } from './LoadingState';

--- a/apps/web/components/properties/HouseList.tsx
+++ b/apps/web/components/properties/HouseList.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/dashboard/states';
 import type { House } from '@/lib/queries/house';
 
 type HouseListProps = {
@@ -16,13 +17,11 @@ type HouseListProps = {
 export default function HouseList({ houses, onDelete, deleting }: HouseListProps) {
   if (houses.length === 0) {
     return (
-      <Card>
-        <CardContent className="py-12 text-center">
-          <p className="text-muted-foreground">
-            No properties yet. Create your first one to get started.
-          </p>
-        </CardContent>
-      </Card>
+      <EmptyState
+        icon="properties"
+        title="No properties yet"
+        message="Create your first property to start managing your community's units and houses."
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- **Sidebar Navigation (#50):** Replaced the thin top nav bar with a 240px collapsible left sidebar. Includes lucide-react icons, active route highlighting (orange left border + bold), "Coming soon" badges for future features (Proposals, Voting, Reports), mobile hamburger menu with overlay, desktop collapse-to-icons mode, and user profile section at the bottom with Clerk UserButton.
- **Dashboard Redesign (#51):** Transformed the empty dashboard into a real management overview with stat cards (Properties, Members, Board Members, Unassigned), quick action buttons (Add Property, Invite Member, Manage Committee), recent members list with avatars, properties summary panel, and an onboarding checklist with progress bar that auto-hides when complete.
- **Error/Empty/Loading States (#52):** Created reusable `ErrorState`, `EmptyState`, and skeleton loading components. ErrorState shows an alert illustration with retry button and dashboard link. EmptyState shows context-specific icons with encouraging messages and CTAs. Loading states use shimmer skeleton placeholders matching final layout shapes. Applied across all dashboard pages (Properties, Committee, Settings, Property Detail).

### Files Changed

| Area | Files | What |
|------|-------|------|
| Sidebar | `components/dashboard/Sidebar.tsx` | New sidebar with SidebarLayout context |
| Layout | `app/dashboard/layout.tsx` | Replaced top nav with SidebarLayout |
| Dashboard | `app/dashboard/page.tsx` | Full redesign with stats, actions, members |
| States | `components/dashboard/states/*` | ErrorState, EmptyState, LoadingState skeletons |
| Properties | `app/dashboard/properties/page.tsx`, `[id]/page.tsx` | Applied new states |
| Committee | `app/dashboard/committee/page.tsx` | Applied new states |
| Settings | `app/dashboard/settings/page.tsx` | Applied new states |
| HouseList | `components/properties/HouseList.tsx` | Uses EmptyState component |

Closes #50
Closes #51
Closes #52

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint clean (`pnpm lint`)
- [x] All existing tests pass (`pnpm test`)
- [ ] Manual: Verify sidebar renders on all `/dashboard/*` routes with correct active state
- [ ] Manual: Verify sidebar collapses on desktop and uses hamburger on mobile
- [ ] Manual: Verify dashboard shows real stat data from API
- [ ] Manual: Verify skeleton loading states appear before data loads
- [ ] Manual: Verify error states show retry button and dashboard link

🤖 Generated with [Claude Code](https://claude.com/claude-code)