### PR TITLE
feat: P1 Role-Specific UI Behavior E2E Tests

### DIFF
--- a/apps/web/e2e/committee-roles.spec.ts
+++ b/apps/web/e2e/committee-roles.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from './fixtures/auth';
+
+/**
+ * Committee page — role-specific controls per role (Issue #68)
+ * Uses real Clerk login to verify committee page adapts to each role.
+ */
+
+test.describe('Committee — Admin role', () => {
+  test('admin sees role change dropdowns', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/committee');
+    await adminPage.waitForTimeout(2000);
+
+    // Admin should see at least one role dropdown (select element)
+    const dropdowns = adminPage.locator('select');
+    const count = await dropdowns.count();
+    if (count > 0) {
+      await expect(dropdowns.first()).toBeVisible();
+    }
+  });
+
+  test('admin sees Board Members section', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/committee');
+    await expect(adminPage.getByText(/Board Members/i)).toBeVisible();
+  });
+
+  test('admin sees Members & Residents section', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/committee');
+    await expect(adminPage.getByText(/Members & Residents/i)).toBeVisible();
+  });
+});
+
+test.describe('Committee — Resident role', () => {
+  test('resident sees member list but no role dropdowns', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard/committee');
+    await residentPage.waitForTimeout(2000);
+
+    // Should see member sections
+    await expect(residentPage.getByText(/Board Members/i)).toBeVisible();
+
+    // Should NOT see any role change dropdowns
+    const dropdowns = residentPage.locator('select');
+    await expect(dropdowns).toHaveCount(0);
+  });
+});
+
+test.describe('Committee — Member role', () => {
+  test('member sees member list but no role dropdowns', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard/committee');
+    await memberPage.waitForTimeout(2000);
+
+    // Should see member sections
+    await expect(memberPage.getByText(/Board Members/i)).toBeVisible();
+
+    // Should NOT see any role change dropdowns
+    const dropdowns = memberPage.locator('select');
+    await expect(dropdowns).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/dashboard-roles.spec.ts
+++ b/apps/web/e2e/dashboard-roles.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from './fixtures/auth';
+
+/**
+ * Dashboard page — role-specific content per role (Issue #66)
+ * Uses real Clerk login to verify the dashboard adapts to each role.
+ */
+
+test.describe('Dashboard — Admin role', () => {
+  test('admin sees Quick Actions section', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard');
+    await expect(adminPage.getByText('Quick Actions')).toBeVisible();
+    await expect(adminPage.getByRole('link', { name: /Add Property/i })).toBeVisible();
+    await expect(adminPage.getByRole('link', { name: /Invite Member/i })).toBeVisible();
+    await expect(adminPage.getByRole('link', { name: /Manage Committee/i })).toBeVisible();
+  });
+
+  test('admin sees stat cards', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard');
+    await expect(adminPage.getByText('Properties')).toBeVisible();
+    await expect(adminPage.getByText('Members')).toBeVisible();
+  });
+});
+
+test.describe('Dashboard — Resident role', () => {
+  test('resident does NOT see Quick Actions section', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard');
+    await expect(residentPage.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(residentPage.getByText('Quick Actions')).not.toBeVisible();
+  });
+
+  test('resident sees stat cards', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard');
+    await expect(residentPage.getByText('Properties')).toBeVisible();
+    await expect(residentPage.getByText('Members')).toBeVisible();
+  });
+});
+
+test.describe('Dashboard — Member role', () => {
+  test('member does NOT see Quick Actions section', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard');
+    await expect(memberPage.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(memberPage.getByText('Quick Actions')).not.toBeVisible();
+  });
+
+  test('member sees stat cards', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard');
+    await expect(memberPage.getByText('Properties')).toBeVisible();
+    await expect(memberPage.getByText('Members')).toBeVisible();
+  });
+});

--- a/apps/web/e2e/properties-roles.spec.ts
+++ b/apps/web/e2e/properties-roles.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from './fixtures/auth';
+
+/**
+ * Properties page — role-specific actions per role (Issue #67)
+ * Uses real Clerk login to verify properties page adapts to each role.
+ */
+
+test.describe('Properties — Admin role', () => {
+  test('admin sees Add Property button', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/properties');
+    await expect(adminPage.getByRole('button', { name: /Add Property/i })).toBeVisible();
+  });
+
+  test('admin sees Delete buttons on property cards', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/properties');
+    // Wait for properties to load
+    await adminPage.waitForTimeout(2000);
+
+    // If properties exist, admin should see delete buttons
+    const deleteButtons = adminPage.getByRole('button', { name: 'Delete' });
+    const propertyCount = await adminPage.locator('.grid > div').count();
+    if (propertyCount > 0) {
+      await expect(deleteButtons.first()).toBeVisible();
+    }
+  });
+
+  test('admin sees Edit button on property detail page', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/properties');
+    await adminPage.waitForTimeout(2000);
+
+    // Click on the first property to go to detail
+    const firstProperty = adminPage.locator('.grid > div').first();
+    const propertyLink = firstProperty.locator('a').first();
+    const hasProperties = await firstProperty.isVisible().catch(() => false);
+
+    if (hasProperties) {
+      await propertyLink.click();
+      await expect(adminPage.getByRole('button', { name: 'Edit' })).toBeVisible();
+    }
+  });
+});
+
+test.describe('Properties — Resident role', () => {
+  test('resident does NOT see Add Property button', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard/properties');
+    await residentPage.waitForTimeout(2000);
+    await expect(residentPage.getByRole('button', { name: /Add Property/i })).not.toBeVisible();
+  });
+
+  test('resident does NOT see Delete buttons', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard/properties');
+    await residentPage.waitForTimeout(2000);
+    await expect(residentPage.getByRole('button', { name: 'Delete' }).first()).not.toBeVisible();
+  });
+});
+
+test.describe('Properties — Member role', () => {
+  test('member does NOT see Add Property button', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard/properties');
+    await memberPage.waitForTimeout(2000);
+    await expect(memberPage.getByRole('button', { name: /Add Property/i })).not.toBeVisible();
+  });
+
+  test('member does NOT see Delete buttons', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard/properties');
+    await memberPage.waitForTimeout(2000);
+    await expect(memberPage.getByRole('button', { name: 'Delete' }).first()).not.toBeVisible();
+  });
+});

--- a/apps/web/e2e/settings-roles.spec.ts
+++ b/apps/web/e2e/settings-roles.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from './fixtures/auth';
+
+/**
+ * Settings page — role-specific tabs and forms per role (Issue #69)
+ * Uses real Clerk login to verify settings page adapts to each role.
+ */
+
+test.describe('Settings — Admin role', () => {
+  test('admin sees invite form with email input and role selector', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/settings');
+    await expect(adminPage.getByText('Invite New Member')).toBeVisible();
+    await expect(adminPage.getByLabel('Email Address')).toBeVisible();
+    await expect(adminPage.getByRole('button', { name: /Send Invite/i })).toBeVisible();
+  });
+
+  test('admin sees members table', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/settings');
+    await expect(adminPage.getByText('Members')).toBeVisible();
+  });
+
+  test('admin can search members', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/settings');
+    const searchInput = adminPage.getByPlaceholder('Search members...');
+    await expect(searchInput).toBeVisible();
+  });
+
+  test('admin sees organization tab with editable fields', async ({ adminPage }) => {
+    await adminPage.goto('/dashboard/settings?tab=organization');
+    await expect(adminPage.getByText('Organization Profile')).toBeVisible();
+    // Admin should NOT see the "only administrators" restriction message
+    await expect(
+      adminPage.getByText('Only administrators can edit organization details.')
+    ).not.toBeVisible();
+  });
+});
+
+test.describe('Settings — Resident role', () => {
+  test('resident sees "only administrators" message instead of invite form', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard/settings');
+    await expect(
+      residentPage.getByText('Only administrators can invite new members')
+    ).toBeVisible();
+    await expect(residentPage.getByLabel('Email Address')).not.toBeVisible();
+  });
+
+  test('resident sees members table', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard/settings');
+    await expect(residentPage.getByText('Members')).toBeVisible();
+  });
+
+  test('resident sees disabled org fields on organization tab', async ({ residentPage }) => {
+    await residentPage.goto('/dashboard/settings?tab=organization');
+    await expect(
+      residentPage.getByText('Only administrators can edit organization details.')
+    ).toBeVisible();
+  });
+});
+
+test.describe('Settings — Member role', () => {
+  test('member sees "only administrators" message instead of invite form', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard/settings');
+    await expect(
+      memberPage.getByText('Only administrators can invite new members')
+    ).toBeVisible();
+    await expect(memberPage.getByLabel('Email Address')).not.toBeVisible();
+  });
+
+  test('member sees members table', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard/settings');
+    await expect(memberPage.getByText('Members')).toBeVisible();
+  });
+
+  test('member sees disabled org fields on organization tab', async ({ memberPage }) => {
+    await memberPage.goto('/dashboard/settings?tab=organization');
+    await expect(
+      memberPage.getByText('Only administrators can edit organization details.')
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Dashboard role tests: Quick Actions visibility, stat cards for all roles
- Properties role tests: Add/Delete/Edit button visibility per role
- Committee role tests: Role change dropdown visibility per role
- Settings role tests: Invite form, org profile fields, admin-only messages

### Issues Addressed

| # | Issue | Spec File |
|---|-------|-----------|
| #66 | Dashboard page — role-specific content | `dashboard-roles.spec.ts` |
| #67 | Properties page — role-specific actions | `properties-roles.spec.ts` |
| #68 | Committee page — role-specific controls | `committee-roles.spec.ts` |
| #69 | Settings page — role-specific tabs/forms | `settings-roles.spec.ts` |

Closes #66
Closes #67
Closes #68
Closes #69

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Tests use real auth fixtures from P0 milestone
- [ ] Real auth tests pass against live services

🤖 Generated with [Claude Code](https://claude.com/claude-code)