### PR TITLE
fix: /api/upload returning 404 due to vercel.json routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "routes": [
     {
-      "src": "/api/(.*)",
+      "src": "/api/(?!upload)(.*)",
       "dest": "api/index.py"
     },
     {


### PR DESCRIPTION
## Summary
- `/api/upload` was returning 404 because `vercel.json` routed all `/api/*` requests to the Python backend
- Added negative lookahead `(?!upload)` to exclude `/api/upload` from the Python route, letting it fall through to Next.js

## Test plan
- [ ] Upload a file on a proposal page and verify it succeeds
- [ ] Verify GraphQL API (`/api/graphql`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)