### PR TITLE
fix: add error handling to upload route

### DIFF
--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -42,15 +42,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const blob = await put(file.name, file, {
-    access: 'public',
-    contentType: file.type,
-  });
+  try {
+    const blob = await put(file.name, file, {
+      access: 'public',
+      contentType: file.type,
+    });
 
-  return NextResponse.json({
-    url: blob.url,
-    fileName: file.name,
-    fileSize: file.size,
-    mimeType: file.type,
-  });
+    return NextResponse.json({
+      url: blob.url,
+      fileName: file.name,
+      fileSize: file.size,
+      mimeType: file.type,
+    });
+  } catch (error) {
+    console.error('Upload error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Upload failed' },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Upload route's `put()` call had no try/catch, returning generic 500 on failure
- Added error handling to log and return the actual error message for debugging

## Test plan
- [ ] Try uploading a file and check the error message in the response
- [ ] Check Vercel function logs for the detailed error

🤖 Generated with [Claude Code](https://claude.com/claude-code)