### PR TITLE
fix: upload auth using clerkClient instead of middleware-dependent auth()

### DIFF
--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -1,6 +1,10 @@
 import { put } from '@vercel/blob';
-import { auth } from '@clerk/nextjs/server';
+import { createClerkClient } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
+
+const clerkClient = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+});
 
 const ALLOWED_MIME_TYPES = new Set([
   'application/pdf',
@@ -16,8 +20,8 @@ const ALLOWED_MIME_TYPES = new Set([
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const { userId } = await auth();
-  if (!userId) {
+  const { isSignedIn } = await clerkClient.authenticateRequest(request);
+  if (!isSignedIn) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -59,5 +59,5 @@ export default clerkMiddleware(async (auth, request) => {
 });
 
 export const config = {
-  matcher: ['/((?!api|_next|.*\\..*).*)', '/api/upload']
+  matcher: ['/((?!api|_next|.*\\..*).*)']
 };


### PR DESCRIPTION
## Summary
- Vercel's legacy `routes` config bypasses Next.js middleware, so `auth()` always fails on `/api/upload`
- Replaced with `clerkClient.authenticateRequest()` which verifies the session token directly
- Reverted unnecessary middleware matcher change from PR #101

## Test plan
- [ ] Upload a file on a proposal page and verify it succeeds
- [ ] Verify unauthenticated requests are rejected with 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)