### PR TITLE
fix: add publishableKey to upload route Clerk config

### DIFF
--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const clerkClient = createClerkClient({
   secretKey: process.env.CLERK_SECRET_KEY,
+  publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
 });
 
 const ALLOWED_MIME_TYPES = new Set([


### PR DESCRIPTION
## Summary
- `authenticateRequest()` requires both `secretKey` and `publishableKey`
- Added `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` to the `createClerkClient` config

## Test plan
- [ ] Upload a file on a proposal page

🤖 Generated with [Claude Code](https://claude.com/claude-code)