### PR TITLE
fix: correct relative import in budget resolver

### DIFF
--- a/apps/api/resolvers/budget.py
+++ b/apps/api/resolvers/budget.py
@@ -38,7 +38,7 @@ async def resolve_proposal_budget(
         raise Exception("Proposal not found")
     await require_org_member(user, proposal["organization_id"])
 
-    from ...database import db
+    from ..database import db
 
     total_houses = await db.db.houses.count_documents(
         {"organization_id": proposal["organization_id"]}
@@ -84,7 +84,7 @@ async def resolve_set_budget(
 
     created_by = user.get("id") or str(user.get("_id"))
 
-    from ...database import db
+    from ..database import db
 
     total_houses = await db.db.houses.count_documents(
         {"organization_id": proposal["organization_id"]}
@@ -107,7 +107,7 @@ async def resolve_update_spent_amount(
         raise Exception("Proposal not found")
     await require_org_admin(user, proposal["organization_id"])
 
-    from ...database import db
+    from ..database import db
 
     total_houses = await db.db.houses.count_documents(
         {"organization_id": proposal["organization_id"]}


### PR DESCRIPTION
## Summary
- Fixed wrong relative import in `apps/api/resolvers/budget.py` — used `from ...database` (3 dots, resolves to nonexistent `apps/database.py`) instead of `from ..database` (2 dots, resolves to `apps/api/database.py`)
- This caused all budget operations (`setBudget`, `proposalBudget`, `updateSpentAmount`) to fail with an `ImportError` in production
- All 3 lazy imports in the file were affected (lines 41, 87, 110)

## Test plan
- [x] All 141 backend tests pass
- [ ] Verify `setBudget` mutation works in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)