### PR TITLE
fix: invitation acceptance now adds user to organization

### DIFF
--- a/apps/api/src/auth/dependencies.py
+++ b/apps/api/src/auth/dependencies.py
@@ -8,6 +8,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from ...database import db
 from .utils import verify_clerk_token
+from .webhooks import process_pending_invitations
 
 security = HTTPBearer()
 security_optional = HTTPBearer(auto_error=False)
@@ -65,43 +66,7 @@ async def _provision_user_from_clerk(clerk_id: str) -> Optional[dict]:
     user = await db.db.users.find_one({"_id": result.inserted_id})
     print(f"JIT provisioned user {clerk_id} in local DB")
 
-    # Check for pending invitations matching this email (mirrors webhooks.py logic)
-    inv_cursor = db.db.invitations.find(
-        {
-            "email": primary_email,
-            "accepted_at": None,
-            "expires_at": {"$gt": now},
-        }
-    )
-    async for invite in inv_cursor:
-        # Guard against duplicates if webhook also fires
-        existing_member = await db.db.organization_members.find_one(
-            {
-                "user_id": str(user["_id"]),
-                "organization_id": invite["organization_id"],
-            }
-        )
-        if existing_member:
-            continue
-
-        member_data = {
-            "user_id": str(user["_id"]),
-            "organization_id": invite["organization_id"],
-            "role": invite["role"],
-            "house_id": invite.get("house_id"),
-            "created_at": now,
-            "updated_at": now,
-        }
-        await db.db.organization_members.insert_one(member_data)
-
-        await db.db.invitations.update_one(
-            {"_id": invite["_id"]},
-            {"$set": {"accepted_at": now, "updated_at": now}},
-        )
-        print(
-            f"JIT: User {clerk_id} auto-joined org "
-            f"{invite['organization_id']} via invitation"
-        )
+    await process_pending_invitations(user)
 
     return user
 
@@ -133,6 +98,11 @@ async def get_current_user(auth: HTTPAuthorizationCredentials = Security(securit
                 status_code=401,
                 detail="User record not found. Identity sync may be in progress.",
             )
+    else:
+        # Safety net: process any pending invitations that a previous
+        # webhook call may have missed (e.g. serverless function killed
+        # before background task completed).
+        await process_pending_invitations(user)
 
     # Convert ObjectId to string for the id field
     user["id"] = str(user["_id"])

--- a/apps/api/src/auth/router.py
+++ b/apps/api/src/auth/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, Request
 
 from .webhooks import handle_user_created, handle_user_updated, verify_clerk_webhook
 
@@ -6,9 +6,11 @@ router = APIRouter(prefix="/webhooks")
 
 
 @router.post("/clerk")
-async def clerk_webhook(request: Request, background_tasks: BackgroundTasks):
+async def clerk_webhook(request: Request):
     """
     Endpoint that Clerk calls when user events occur.
+    Handlers run synchronously to ensure they complete before the
+    serverless function shuts down (BackgroundTasks are unreliable on Vercel).
     """
     msg = await verify_clerk_webhook(request)
 
@@ -16,9 +18,8 @@ async def clerk_webhook(request: Request, background_tasks: BackgroundTasks):
     data = msg.get("data")
 
     if event_type == "user.created":
-        # Use background tasks to respond quickly to Clerk
-        background_tasks.add_task(handle_user_created, data)
+        await handle_user_created(data)
     elif event_type == "user.updated":
-        background_tasks.add_task(handle_user_updated, data)
+        await handle_user_updated(data)
 
     return {"status": "ok"}

--- a/apps/api/src/auth/webhooks.py
+++ b/apps/api/src/auth/webhooks.py
@@ -46,6 +46,57 @@ async def verify_clerk_webhook(request: Request):
         )
 
 
+async def process_pending_invitations(user: dict):
+    """
+    Finds pending invitations matching the user's email and creates
+    organization memberships.  Idempotent — safe to call multiple times.
+    """
+    email = user.get("email")
+    if not email:
+        return
+
+    if not db.is_connected():
+        await db.connect()
+
+    now = datetime.utcnow()
+    cursor = db.db.invitations.find(
+        {
+            "email": email,
+            "accepted_at": None,
+            "expires_at": {"$gt": now},
+        }
+    )
+
+    async for invite in cursor:
+        # Guard against duplicates (webhook + JIT race condition)
+        existing_member = await db.db.organization_members.find_one(
+            {
+                "user_id": str(user["_id"]),
+                "organization_id": invite["organization_id"],
+            }
+        )
+        if existing_member:
+            continue
+
+        member_data = {
+            "user_id": str(user["_id"]),
+            "organization_id": invite["organization_id"],
+            "role": invite["role"],
+            "house_id": invite.get("house_id"),
+            "created_at": now,
+            "updated_at": now,
+        }
+        await db.db.organization_members.insert_one(member_data)
+
+        await db.db.invitations.update_one(
+            {"_id": invite["_id"]}, {"$set": {"accepted_at": now, "updated_at": now}}
+        )
+        print(
+            f"User {user.get('clerk_id', user['_id'])} auto-joined "
+            f"organization {invite['organization_id']} via invitation"
+        )
+
+
 async def handle_user_created(data: dict):
     """
     Syncs a newly created Clerk user to our local database.
@@ -104,44 +155,7 @@ async def handle_user_created(data: dict):
 
     print(f"User {clerk_id} created/synced in local DB")
 
-    # Check for pending invitations matching this email
-    cursor = db.db.invitations.find(
-        {
-            "email": primary_email,
-            "accepted_at": None,
-            "expires_at": {"$gt": now},
-        }
-    )
-
-    async for invite in cursor:
-        # Guard against duplicates (webhook + JIT race condition)
-        existing_member = await db.db.organization_members.find_one(
-            {
-                "user_id": str(user["_id"]),
-                "organization_id": invite["organization_id"],
-            }
-        )
-        if existing_member:
-            continue
-
-        # Add user to organization
-        member_data = {
-            "user_id": str(user["_id"]),
-            "organization_id": invite["organization_id"],
-            "role": invite["role"],
-            "house_id": invite.get("house_id"),
-            "created_at": now,
-            "updated_at": now,
-        }
-        await db.db.organization_members.insert_one(member_data)
-
-        # Mark invitation as accepted
-        await db.db.invitations.update_one(
-            {"_id": invite["_id"]}, {"$set": {"accepted_at": now, "updated_at": now}}
-        )
-        print(
-            f"User {clerk_id} auto-joined organization {invite['organization_id']} via invitation"
-        )
+    await process_pending_invitations(user)
 
 
 async def handle_user_updated(data: dict):


### PR DESCRIPTION
## Summary
- **Root cause**: `BackgroundTasks` in the Clerk webhook endpoint don't reliably complete on Vercel serverless — the function terminates after returning the HTTP response, killing the background invitation processing
- Webhook handlers now run synchronously (`await`) instead of via `background_tasks.add_task()`
- Added a safety net: `get_current_user()` processes any pending invitations for existing users on every auth request, self-healing users affected by previously broken webhook calls

## Details
Three files changed:

**`router.py`** — Removed `BackgroundTasks` dependency; handlers are now awaited directly so they complete before the serverless function shuts down.

**`webhooks.py`** — Extracted `process_pending_invitations(user)` as a shared, idempotent helper. Called from `handle_user_created` and reused by `dependencies.py`.

**`dependencies.py`** — After finding an existing user, calls `process_pending_invitations()` as a safety net. Also simplified JIT provisioning to use the same shared helper (removed duplicated invitation logic).

Closes #137

## Test plan
- [x] All 141 backend tests pass
- [x] Black formatting check passes
- [ ] Manual E2E: send invitation → accept → verify user lands in org dashboard with correct role

🤖 Generated with [Claude Code](https://claude.com/claude-code)