### PR TITLE
fix: use client-side auth guard for dashboard

### DIFF
--- a/apps/web/app/dashboard/layout-client.tsx
+++ b/apps/web/app/dashboard/layout-client.tsx
@@ -1,8 +1,0 @@
-'use client';
-
-import { ReactNode } from 'react';
-import { SidebarLayout } from '@/components/dashboard/Sidebar';
-
-export function DashboardLayoutClient({ children }: { children: ReactNode }) {
-  return <SidebarLayout>{children}</SidebarLayout>;
-}

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -1,12 +1,19 @@
-import { ReactNode } from 'react';
-import { auth } from '@clerk/nextjs/server';
-import { redirect } from 'next/navigation';
-import { DashboardLayoutClient } from './layout-client';
+'use client';
 
-export default async function DashboardLayout({ children }: { children: ReactNode }) {
-  const { userId } = await auth();
-  if (!userId) {
-    redirect('/sign-in');
+import { ReactNode } from 'react';
+import { useAuth, RedirectToSignIn } from '@clerk/nextjs';
+import { SidebarLayout } from '@/components/dashboard/Sidebar';
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  const { isLoaded, isSignedIn } = useAuth();
+
+  if (!isLoaded) {
+    return null;
   }
-  return <DashboardLayoutClient>{children}</DashboardLayoutClient>;
+
+  if (!isSignedIn) {
+    return <RedirectToSignIn />;
+  }
+
+  return <SidebarLayout>{children}</SidebarLayout>;
 }


### PR DESCRIPTION
## Summary
- Server-side `auth()` from Clerk requires `clerkMiddleware()` to have run first
- `vercel.json` uses platform-level `routes` which bypass Next.js middleware entirely
- Switched to client-side `useAuth()` + `<RedirectToSignIn />` which works independently of middleware
- Removed unused `layout-client.tsx`

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] Visit `/dashboard` unauthenticated — should redirect to sign-in
- [ ] Visit `/dashboard` authenticated — should render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)