### PR TITLE
fix: handle duplicate Clerk invitation error gracefully

### DIFF
--- a/apps/api/src/auth/service.py
+++ b/apps/api/src/auth/service.py
@@ -150,7 +150,8 @@ async def create_invitation(
         )
         print(f"Clerk invitation sent to {email}")
     except HTTPException as e:
-        if e.status_code == 422 and "form_identifier_exists" in str(e.detail):
+        detail = str(e.detail)
+        if e.status_code == 422 and "form_identifier_exists" in detail:
             print(f"User {email} already exists in Clerk. Sending in-app notification.")
             # Notify existing user via in-app notification
             existing_user = await db.db.users.find_one({"email": email})
@@ -167,6 +168,10 @@ async def create_invitation(
                     message=f"You have been invited to join {org_name}",
                     reference_id=str(invitation_data["_id"]),
                 )
+        elif "duplicate" in detail.lower():
+            print(
+                f"Duplicate Clerk invitation for {email}, continuing with local record."
+            )
         else:
             print(f"Failed to send Clerk invitation: {e}")
             raise e

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -293,9 +293,16 @@ function MembersTab({
       setEmail('');
       setInviteSuccess(true);
       setTimeout(() => setInviteSuccess(false), 3000);
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(err);
-      alert('Failed to send invitation.');
+      const message = err instanceof Error ? err.message : '';
+      if (message.toLowerCase().includes('already pending')) {
+        alert(t('settings.duplicateInvitation'));
+      } else if (message.toLowerCase().includes('already exists')) {
+        alert(t('settings.existingUserNotified'));
+      } else {
+        alert(t('settings.inviteFailed'));
+      }
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -560,6 +560,7 @@
       "emailPlaceholder": "colleague@example.com",
       "sendInvite": "Send Invite",
       "inviteSent": "Invitation sent successfully!",
+      "inviteFailed": "Failed to send invitation.",
       "pendingInvitations": "Pending Invitations",
       "noPendingInvitations": "No pending invitations.",
       "resendInvite": "Resend",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -560,6 +560,7 @@
       "emailPlaceholder": "colega@ejemplo.com",
       "sendInvite": "Enviar invitación",
       "inviteSent": "¡Invitación enviada con éxito!",
+      "inviteFailed": "No se pudo enviar la invitación.",
       "pendingInvitations": "Invitaciones Pendientes",
       "noPendingInvitations": "No hay invitaciones pendientes.",
       "resendInvite": "Reenviar",


### PR DESCRIPTION
## Summary
- Backend: catch Clerk's `duplicate_record` error (HTTP 400) when resending invitations, log it, and continue since the local invitation record already exists
- Frontend: replace generic `alert('Failed to send invitation.')` with translated, context-specific messages for "already pending", "already exists", and generic failures
- Added `inviteFailed` translation key to both `en.json` and `es.json`

Closes #166

## Test plan
- [x] Backend tests pass (141 passed)
- [x] Lint passes (Black, isort, flake8, ESLint)
- [x] TypeScript typecheck passes
- [ ] Manual: invite same email twice → should show "already pending" message
- [ ] Manual: invite existing Clerk user → should show notification message

🤖 Generated with [Claude Code](https://claude.com/claude-code)