### PR TITLE
fix: reload pending invitations after sending an invite

### DIFF
--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -269,6 +269,7 @@ function MembersTab({
   const [submitting, setSubmitting] = useState(false);
   const [inviteSuccess, setInviteSuccess] = useState(false);
   const [removingId, setRemovingId] = useState<string | null>(null);
+  const [inviteRefresh, setInviteRefresh] = useState(0);
 
   const filteredMembers = members.filter((m) => {
     const q = search.toLowerCase();
@@ -292,6 +293,7 @@ function MembersTab({
       await client.request(CREATE_INVITATION, { email, organizationId, role });
       setEmail('');
       setInviteSuccess(true);
+      setInviteRefresh((n) => n + 1);
       setTimeout(() => setInviteSuccess(false), 3000);
     } catch (err: unknown) {
       console.error(err);
@@ -498,6 +500,7 @@ function MembersTab({
           organizationId={organizationId}
           getAuthToken={getAuthToken}
           t={t}
+          refreshTrigger={inviteRefresh}
         />
       )}
     </div>

--- a/apps/web/components/settings/PendingInvitationsTable.tsx
+++ b/apps/web/components/settings/PendingInvitationsTable.tsx
@@ -17,12 +17,14 @@ type PendingInvitationsTableProps = {
   organizationId: string;
   getAuthToken: () => Promise<string | null>;
   t: (key: string, values?: Record<string, string | number>) => string;
+  refreshTrigger?: number;
 };
 
 export default function PendingInvitationsTable({
   organizationId,
   getAuthToken,
   t,
+  refreshTrigger,
 }: PendingInvitationsTableProps) {
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -46,7 +48,7 @@ export default function PendingInvitationsTable({
 
   useEffect(() => {
     fetchInvitations();
-  }, [fetchInvitations]);
+  }, [fetchInvitations, refreshTrigger]);
 
   const handleRevoke = async (invitationId: string) => {
     setActionLoading(invitationId);


### PR DESCRIPTION
## Summary
- Pending invitations table now automatically refreshes after a successful invite
- Added `refreshTrigger` prop to `PendingInvitationsTable` — incremented on invite success

## Test plan
- [x] TypeScript typecheck passes
- [ ] Manual: send invite → pending invitations table updates without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)