### PR TITLE
fix: revoke old Clerk invitations before creating new ones

### DIFF
--- a/apps/api/src/auth/clerk_utils.py
+++ b/apps/api/src/auth/clerk_utils.py
@@ -35,13 +35,22 @@ async def create_clerk_invitation(
     if redirect_url:
         payload["redirect_url"] = redirect_url
 
+    print(f"Clerk invitation request: email={email}, redirect_url={redirect_url}")
+
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(url, json=payload, headers=headers)
+            print(f"Clerk invitation response: status={response.status_code}")
             response.raise_for_status()
-            return response.json()
+            result = response.json()
+            print(
+                f"Clerk invitation created: id={result.get('id')}, status={result.get('status')}"
+            )
+            return result
         except httpx.HTTPStatusError as e:
-            print(f"Clerk API Error: {e.response.text}")
+            print(
+                f"Clerk API Error: status={e.response.status_code}, body={e.response.text}"
+            )
             raise HTTPException(
                 status_code=e.response.status_code,
                 detail=f"Failed to create Clerk invitation: {e.response.text}",
@@ -49,6 +58,52 @@ async def create_clerk_invitation(
         except Exception as e:
             print(f"Error calling Clerk API: {e}")
             raise HTTPException(status_code=500, detail=str(e))
+
+
+async def revoke_clerk_invitations_for_email(email: str):
+    """
+    Revoke all existing Clerk invitations for an email address.
+    This is needed before creating a new invitation, since Clerk
+    rejects duplicates even for revoked/accepted invitations.
+    """
+    if not CLERK_SECRET_KEY:
+        return
+
+    headers = {
+        "Authorization": f"Bearer {CLERK_SECRET_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient() as client:
+        # List all invitations
+        try:
+            response = await client.get(
+                "https://api.clerk.com/v1/invitations",
+                headers=headers,
+            )
+            response.raise_for_status()
+            invitations = response.json()
+        except Exception as e:
+            print(f"Failed to list Clerk invitations: {e}")
+            return
+
+        # Revoke any pending invitations for this email
+        for inv in (
+            invitations.get("data", invitations)
+            if isinstance(invitations, dict)
+            else invitations
+        ):
+            if inv.get("email_address") == email and inv.get("status") == "pending":
+                inv_id = inv["id"]
+                try:
+                    revoke_resp = await client.post(
+                        f"https://api.clerk.com/v1/invitations/{inv_id}/revoke",
+                        headers=headers,
+                    )
+                    revoke_resp.raise_for_status()
+                    print(f"Revoked Clerk invitation {inv_id} for {email}")
+                except Exception as e:
+                    print(f"Failed to revoke Clerk invitation {inv_id}: {e}")
 
 
 async def delete_clerk_user(clerk_id: str):

--- a/apps/api/src/auth/service.py
+++ b/apps/api/src/auth/service.py
@@ -6,7 +6,11 @@ from bson import ObjectId
 from fastapi import HTTPException
 
 from ...database import db
-from .clerk_utils import create_clerk_invitation, delete_clerk_user
+from .clerk_utils import (
+    create_clerk_invitation,
+    delete_clerk_user,
+    revoke_clerk_invitations_for_email,
+)
 
 EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
@@ -135,6 +139,9 @@ async def create_invitation(
     result = await db.db.invitations.insert_one(invitation_data)
     invitation_data["_id"] = str(result.inserted_id)
 
+    # Revoke any existing Clerk invitations for this email before creating a new one
+    await revoke_clerk_invitations_for_email(email)
+
     # Trigger Clerk Invitation
     redirect_url = f"{_get_app_url()}/dashboard"
 
@@ -168,10 +175,6 @@ async def create_invitation(
                     message=f"You have been invited to join {org_name}",
                     reference_id=str(invitation_data["_id"]),
                 )
-        elif "duplicate" in detail.lower():
-            print(
-                f"Duplicate Clerk invitation for {email}, continuing with local record."
-            )
         else:
             print(f"Failed to send Clerk invitation: {e}")
             raise e
@@ -277,6 +280,9 @@ async def revoke_invitation(invitation_id: str):
     if invitation.get("accepted_at"):
         raise Exception("Cannot revoke an already accepted invitation")
 
+    # Revoke in Clerk so the email can be re-invited later
+    await revoke_clerk_invitations_for_email(invitation["email"])
+
     await db.db.invitations.delete_one({"_id": ObjectId(invitation_id)})
     return invitation["organization_id"]
 
@@ -292,6 +298,9 @@ async def resend_invitation(invitation_id: str):
 
     if invitation.get("accepted_at"):
         raise Exception("Cannot resend an already accepted invitation")
+
+    # Revoke old Clerk invitation before creating a new one
+    await revoke_clerk_invitations_for_email(invitation["email"])
 
     # Resend via Clerk
     redirect_url = f"{_get_app_url()}/dashboard"

--- a/apps/api/tests/auth/test_invitation_service.py
+++ b/apps/api/tests/auth/test_invitation_service.py
@@ -21,10 +21,14 @@ from apps.api.tests.conftest import (
 )
 
 
+@patch(
+    "apps.api.src.auth.service.revoke_clerk_invitations_for_email",
+    new_callable=AsyncMock,
+)
 class TestCreateInvitation:
     @pytest.mark.asyncio
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_creates_invitation_successfully(self, mock_clerk):
+    async def test_creates_invitation_successfully(self, mock_clerk, _mock_revoke):
         mock_clerk.return_value = {"id": "clerk_inv_1"}
         inv_id = ObjectId()
         mock_invitations_collection.find_one.return_value = None
@@ -43,12 +47,12 @@ class TestCreateInvitation:
         mock_clerk.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_rejects_invalid_email(self):
+    async def test_rejects_invalid_email(self, _mock_revoke):
         with pytest.raises(Exception, match="Invalid email address format"):
             await create_invitation("not-an-email", "org-1", "inviter-1", "MEMBER")
 
     @pytest.mark.asyncio
-    async def test_rejects_duplicate_pending_invitation(self):
+    async def test_rejects_duplicate_pending_invitation(self, _mock_revoke):
         existing = {
             "_id": ObjectId(),
             "email": "user@example.com",
@@ -63,7 +67,7 @@ class TestCreateInvitation:
 
     @pytest.mark.asyncio
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_replaces_expired_invitation(self, mock_clerk):
+    async def test_replaces_expired_invitation(self, mock_clerk, _mock_revoke):
         mock_clerk.return_value = {"id": "clerk_inv_1"}
         expired = {
             "_id": ObjectId(),
@@ -86,7 +90,7 @@ class TestCreateInvitation:
 
     @pytest.mark.asyncio
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_notifies_existing_clerk_user(self, mock_clerk):
+    async def test_notifies_existing_clerk_user(self, mock_clerk, _mock_revoke):
         from fastapi import HTTPException
 
         mock_clerk.side_effect = HTTPException(
@@ -217,10 +221,15 @@ class TestAcceptInvitationById:
 
 class TestRevokeInvitation:
     @pytest.mark.asyncio
-    async def test_revokes_pending_invitation(self):
+    @patch(
+        "apps.api.src.auth.service.revoke_clerk_invitations_for_email",
+        new_callable=AsyncMock,
+    )
+    async def test_revokes_pending_invitation(self, mock_revoke_clerk):
         inv_id = ObjectId()
         invitation = {
             "_id": inv_id,
+            "email": "user@example.com",
             "organization_id": "org-1",
             "accepted_at": None,
         }
@@ -229,6 +238,7 @@ class TestRevokeInvitation:
         org_id = await revoke_invitation(str(inv_id))
 
         assert org_id == "org-1"
+        mock_revoke_clerk.assert_called_once_with("user@example.com")
         mock_invitations_collection.delete_one.assert_called_once()
 
     @pytest.mark.asyncio
@@ -254,8 +264,12 @@ class TestRevokeInvitation:
 
 class TestResendInvitation:
     @pytest.mark.asyncio
+    @patch(
+        "apps.api.src.auth.service.revoke_clerk_invitations_for_email",
+        new_callable=AsyncMock,
+    )
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_resends_invitation(self, mock_clerk):
+    async def test_resends_invitation(self, mock_clerk, _mock_revoke):
         mock_clerk.return_value = {"id": "clerk_inv_1"}
         inv_id = ObjectId()
         invitation = {


### PR DESCRIPTION
## Summary
- **Root cause**: Clerk rejects duplicate invitations even for revoked/accepted ones, so re-inviting the same email silently failed — no email was ever sent
- Added `revoke_clerk_invitations_for_email()` helper that lists and revokes any pending Clerk invitations for an email before creating a new one
- Applied to: `create_invitation`, `resend_invitation`, and `revoke_invitation` flows
- Added detailed logging to Clerk API calls for easier debugging
- Removed the now-unnecessary `duplicate` error swallowing (since we revoke first, duplicates shouldn't occur)

## Test plan
- [x] All 141 backend tests pass
- [x] Lint passes
- [ ] Manual: invite an email that was previously invited → should create new Clerk invitation and send email
- [ ] Manual: revoke from app → should also revoke in Clerk dashboard
- [ ] Manual: resend invitation → should revoke old + create new in Clerk

🤖 Generated with [Claude Code](https://claude.com/claude-code)