### PR TITLE
fix: handle Clerk duplicate invitation error gracefully

### DIFF
--- a/apps/api/src/auth/service.py
+++ b/apps/api/src/auth/service.py
@@ -156,8 +156,14 @@ async def create_invitation(
         print(f"Clerk invitation sent to {email}")
     except HTTPException as e:
         detail = str(e.detail)
-        if e.status_code == 422 and "form_identifier_exists" in detail:
-            print(f"User {email} already exists in Clerk. Sending in-app notification.")
+        is_existing_user = e.status_code == 422 and "form_identifier_exists" in detail
+        is_duplicate = "duplicate" in detail.lower()
+
+        if is_existing_user or is_duplicate:
+            print(
+                f"User {email} already exists in Clerk or has prior invitation. "
+                "Sending in-app notification."
+            )
             # Notify existing user via in-app notification
             existing_user = await db.db.users.find_one({"email": email})
             if existing_user:


### PR DESCRIPTION
## Summary
- When Clerk returns `duplicate_record` (400), handle it the same way as `form_identifier_exists` (422) — send an in-app notification to the existing user instead of crashing
- This fixes the case where a user was previously invited (accepted invitation still in Clerk), and re-inviting them fails even after revoking pending invitations

## Test plan
- [x] 141 backend tests pass
- [ ] Manual: re-invite yan4talk@gmail.com → should succeed and create in-app notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)