### PR TITLE
fix: resolve voting session detail page crash

### DIFF
--- a/apps/web/app/dashboard/vote/[sessionId]/page.tsx
+++ b/apps/web/app/dashboard/vote/[sessionId]/page.tsx
@@ -38,8 +38,8 @@ const ME_QUERY = `
       memberships {
         organization { id, name }
         role
+        houseId
       }
-      houses { id, unitNumber }
     }
   }
 `;
@@ -47,8 +47,11 @@ const ME_QUERY = `
 type MeResponse = {
   me: {
     id: string;
-    memberships: { organization: { id: string; name: string }; role: string }[];
-    houses: { id: string; unitNumber: string }[];
+    memberships: {
+      organization: { id: string; name: string };
+      role: string;
+      houseId: string | null;
+    }[];
   } | null;
 };
 
@@ -84,8 +87,7 @@ export default function VotingSessionPage() {
         return;
       }
       setIsAdmin(membership.role === 'ADMIN');
-      const house = meData.me?.houses?.[0];
-      if (house) setHouseId(house.id);
+      if (membership.houseId) setHouseId(membership.houseId);
 
       const sessionData = await client.request<{
         votingSession: VotingSession;
@@ -110,11 +112,11 @@ export default function VotingSessionPage() {
         setRankedProposals([...inSession]);
       }
 
-      if (house && sess.status === 'OPEN') {
+      if (membership.houseId && sess.status === 'OPEN') {
         try {
           const voteData = await client.request<{ myVote: Vote | null }>(
             GET_MY_VOTE,
-            { sessionId, houseId: house.id }
+            { sessionId, houseId: membership.houseId }
           );
           if (voteData.myVote) {
             setMyVote(voteData.myVote);


### PR DESCRIPTION
## Summary
- Fixed the voting session detail page (`/dashboard/vote/{id}`) crashing with "No se pudieron cargar las sesiones de votación"
- The `ME_QUERY` was requesting a `houses` field on the `User` GraphQL type, which doesn't exist in the schema
- Changed to use `membership.houseId` which is the correct field path

## Details
The `User` GraphQL type has `memberships` (which contain `houseId`), but no top-level `houses` field. The detail page's `ME_QUERY` incorrectly included `houses { id, unitNumber }`, causing a GraphQL validation error that was caught by the generic error handler, showing the unhelpful "failed to load" message.

The results page (`/dashboard/vote/{id}/results`) worked because it doesn't need house information from the `me` query.

Closes #138

## Test plan
- [x] TypeScript type checking passes
- [x] Frontend tests pass
- [ ] Manual: Navigate to Votaciones, click "Gestionar" on a voting session — page should load correctly
- [ ] Manual: Verify voting functionality still works (cast vote, admin controls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)