### PR TITLE
fix: use Clerk Organization invitations for proper email branding

### DIFF
--- a/apps/api/src/auth/clerk_utils.py
+++ b/apps/api/src/auth/clerk_utils.py
@@ -106,6 +106,120 @@ async def revoke_clerk_invitations_for_email(email: str):
                     print(f"Failed to revoke Clerk invitation {inv_id}: {e}")
 
 
+async def create_clerk_organization(name: str):
+    """
+    Creates an organization in Clerk.
+    Returns the Clerk organization ID, or None on failure.
+    """
+    if not CLERK_SECRET_KEY:
+        return None
+
+    url = "https://api.clerk.com/v1/organizations"
+    headers = {
+        "Authorization": f"Bearer {CLERK_SECRET_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {"name": name}
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+            result = response.json()
+            print(f"Clerk organization created: id={result.get('id')}")
+            return result.get("id")
+        except Exception as e:
+            print(f"Failed to create Clerk organization: {e}")
+            return None
+
+
+async def create_clerk_org_invitation(
+    clerk_org_id: str, email: str, redirect_url: str = None
+):
+    """
+    Creates an organization invitation in Clerk.
+    The invitation email will include the organization name.
+    """
+    if not CLERK_SECRET_KEY:
+        return None
+
+    url = f"https://api.clerk.com/v1/organizations/{clerk_org_id}/invitations"
+    headers = {
+        "Authorization": f"Bearer {CLERK_SECRET_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "email_address": email,
+        "role": "org:member",
+    }
+    if redirect_url:
+        payload["redirect_url"] = redirect_url
+
+    print(f"Clerk org invitation request: org={clerk_org_id}, email={email}")
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(url, json=payload, headers=headers)
+            print(f"Clerk org invitation response: status={response.status_code}")
+            response.raise_for_status()
+            result = response.json()
+            print(f"Clerk org invitation created: id={result.get('id')}")
+            return result
+        except httpx.HTTPStatusError as e:
+            print(
+                f"Clerk org invitation error: status={e.response.status_code}, "
+                f"body={e.response.text}"
+            )
+            raise HTTPException(
+                status_code=e.response.status_code,
+                detail=f"Failed to create Clerk org invitation: {e.response.text}",
+            )
+
+
+async def revoke_clerk_org_invitations_for_email(clerk_org_id: str, email: str):
+    """
+    Revoke pending organization invitations for an email in Clerk.
+    """
+    if not CLERK_SECRET_KEY:
+        return
+
+    headers = {
+        "Authorization": f"Bearer {CLERK_SECRET_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(
+                f"https://api.clerk.com/v1/organizations/{clerk_org_id}/invitations",
+                params={"status": "pending"},
+                headers=headers,
+            )
+            response.raise_for_status()
+            invitations = response.json()
+        except Exception as e:
+            print(f"Failed to list Clerk org invitations: {e}")
+            return
+
+        data = (
+            invitations.get("data", invitations)
+            if isinstance(invitations, dict)
+            else invitations
+        )
+        for inv in data:
+            if inv.get("email_address") == email:
+                inv_id = inv["id"]
+                try:
+                    await client.post(
+                        f"https://api.clerk.com/v1/organizations/{clerk_org_id}"
+                        f"/invitations/{inv_id}/revoke",
+                        headers=headers,
+                    )
+                    print(f"Revoked Clerk org invitation {inv_id} for {email}")
+                except Exception as e:
+                    print(f"Failed to revoke Clerk org invitation {inv_id}: {e}")
+
+
 async def delete_clerk_user(clerk_id: str):
     """
     Deletes a user from Clerk by their Clerk user ID.

--- a/apps/api/src/auth/service.py
+++ b/apps/api/src/auth/service.py
@@ -8,8 +8,11 @@ from fastapi import HTTPException
 from ...database import db
 from .clerk_utils import (
     create_clerk_invitation,
+    create_clerk_org_invitation,
+    create_clerk_organization,
     delete_clerk_user,
     revoke_clerk_invitations_for_email,
+    revoke_clerk_org_invitations_for_email,
 )
 
 EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
@@ -41,6 +44,129 @@ def _slugify(text: str) -> str:
     text = re.sub(r"[^\w\s-]", "", text)
     text = re.sub(r"[-\s]+", "-", text)
     return text.strip("-")
+
+
+async def _send_clerk_invitation(
+    email: str,
+    organization_id: str,
+    redirect_url: str,
+    token: str,
+    role: str,
+    invitation_data: dict,
+    create_notification,
+):
+    """
+    Send a Clerk invitation, preferring organization invitations (which include
+    the org name in the email) with fallback to generic invitations.
+    """
+    clerk_org_id = await _get_or_create_clerk_org_id(organization_id)
+
+    if clerk_org_id:
+        # Use Clerk Organization invitation — email shows the org name
+        await revoke_clerk_org_invitations_for_email(clerk_org_id, email)
+        try:
+            await create_clerk_org_invitation(
+                clerk_org_id=clerk_org_id,
+                email=email,
+                redirect_url=redirect_url,
+            )
+            print(f"Clerk org invitation sent to {email}")
+            return
+        except HTTPException as e:
+            detail = str(e.detail)
+            is_existing_user = (
+                e.status_code == 422 and "form_identifier_exists" in detail
+            )
+            is_duplicate = "duplicate" in detail.lower()
+            is_already_member = "already" in detail.lower()
+
+            if is_existing_user or is_duplicate or is_already_member:
+                print(
+                    f"User {email} already exists or is already a member. "
+                    "Sending in-app notification."
+                )
+                await _notify_existing_user(
+                    email, organization_id, invitation_data, create_notification
+                )
+                return
+            # For other errors, fall through to generic invitation
+            print(f"Clerk org invitation failed, falling back to generic: {e}")
+        except Exception as e:
+            print(f"Clerk org invitation failed, falling back to generic: {e}")
+
+    # Fallback: generic Clerk invitation
+    await revoke_clerk_invitations_for_email(email)
+    try:
+        await create_clerk_invitation(
+            email=email,
+            redirect_url=redirect_url,
+            public_metadata={
+                "organization_id": organization_id,
+                "role": role,
+                "invitation_token": token,
+            },
+        )
+        print(f"Clerk generic invitation sent to {email}")
+    except HTTPException as e:
+        detail = str(e.detail)
+        is_existing_user = e.status_code == 422 and "form_identifier_exists" in detail
+        is_duplicate = "duplicate" in detail.lower()
+
+        if is_existing_user or is_duplicate:
+            print(
+                f"User {email} already exists in Clerk or has prior invitation. "
+                "Sending in-app notification."
+            )
+            await _notify_existing_user(
+                email, organization_id, invitation_data, create_notification
+            )
+        else:
+            print(f"Failed to send Clerk invitation: {e}")
+            raise e
+    except Exception as e:
+        print(f"Failed to send Clerk invitation: {e}")
+        raise e
+
+
+async def _notify_existing_user(
+    email: str, organization_id: str, invitation_data: dict, create_notification
+):
+    """Send an in-app notification to an existing user about a new invitation."""
+    existing_user = await db.db.users.find_one({"email": email})
+    if existing_user:
+        org = await db.db.organizations.find_one({"_id": ObjectId(organization_id)})
+        org_name = org["name"] if org else "an organization"
+        await create_notification(
+            user_id=str(existing_user["_id"]),
+            organization_id=organization_id,
+            notification_type="INVITATION",
+            title="New Invitation",
+            message=f"You have been invited to join {org_name}",
+            reference_id=str(invitation_data["_id"]),
+        )
+
+
+async def _get_or_create_clerk_org_id(organization_id: str):
+    """
+    Get the Clerk organization ID for an app organization.
+    Lazily creates a Clerk organization if one doesn't exist yet.
+    """
+    org = await db.db.organizations.find_one({"_id": ObjectId(organization_id)})
+    if not org:
+        return None
+
+    clerk_org_id = org.get("clerk_org_id")
+    if clerk_org_id:
+        return clerk_org_id
+
+    # Create Clerk organization and store the ID
+    clerk_org_id = await create_clerk_organization(org["name"])
+    if clerk_org_id:
+        await db.db.organizations.update_one(
+            {"_id": ObjectId(organization_id)},
+            {"$set": {"clerk_org_id": clerk_org_id}},
+        )
+    return clerk_org_id
 
 
 async def create_organization(name: str, creator_user_id: str):
@@ -137,54 +263,17 @@ async def create_invitation(
     result = await db.db.invitations.insert_one(invitation_data)
     invitation_data["_id"] = str(result.inserted_id)
 
-    # Revoke any existing Clerk invitations for this email before creating a new one
-    await revoke_clerk_invitations_for_email(email)
-
-    # Trigger Clerk Invitation
     redirect_url = f"{_get_app_url()}/dashboard"
 
-    try:
-        await create_clerk_invitation(
-            email=email,
-            redirect_url=redirect_url,
-            public_metadata={
-                "organization_id": organization_id,
-                "role": role,
-                "invitation_token": token,
-            },
-        )
-        print(f"Clerk invitation sent to {email}")
-    except HTTPException as e:
-        detail = str(e.detail)
-        is_existing_user = e.status_code == 422 and "form_identifier_exists" in detail
-        is_duplicate = "duplicate" in detail.lower()
-
-        if is_existing_user or is_duplicate:
-            print(
-                f"User {email} already exists in Clerk or has prior invitation. "
-                "Sending in-app notification."
-            )
-            # Notify existing user via in-app notification
-            existing_user = await db.db.users.find_one({"email": email})
-            if existing_user:
-                org = await db.db.organizations.find_one(
-                    {"_id": ObjectId(organization_id)}
-                )
-                org_name = org["name"] if org else "an organization"
-                await create_notification(
-                    user_id=str(existing_user["_id"]),
-                    organization_id=organization_id,
-                    notification_type="INVITATION",
-                    title="New Invitation",
-                    message=f"You have been invited to join {org_name}",
-                    reference_id=str(invitation_data["_id"]),
-                )
-        else:
-            print(f"Failed to send Clerk invitation: {e}")
-            raise e
-    except Exception as e:
-        print(f"Failed to send Clerk invitation: {e}")
-        raise e
+    await _send_clerk_invitation(
+        email=email,
+        organization_id=organization_id,
+        redirect_url=redirect_url,
+        token=token,
+        role=role,
+        invitation_data=invitation_data,
+        create_notification=create_notification,
+    )
 
     print(f"Invitation created locally for {email} to join org {organization_id}")
 
@@ -285,6 +374,9 @@ async def revoke_invitation(invitation_id: str):
         raise Exception("Cannot revoke an already accepted invitation")
 
     # Revoke in Clerk so the email can be re-invited later
+    clerk_org_id = await _get_or_create_clerk_org_id(invitation["organization_id"])
+    if clerk_org_id:
+        await revoke_clerk_org_invitations_for_email(clerk_org_id, invitation["email"])
     await revoke_clerk_invitations_for_email(invitation["email"])
 
     await db.db.invitations.delete_one({"_id": ObjectId(invitation_id)})
@@ -303,27 +395,43 @@ async def resend_invitation(invitation_id: str):
     if invitation.get("accepted_at"):
         raise Exception("Cannot resend an already accepted invitation")
 
-    # Revoke old Clerk invitation before creating a new one
-    await revoke_clerk_invitations_for_email(invitation["email"])
-
-    # Resend via Clerk
+    # Resend via Clerk (prefer org invitation for proper email branding)
     redirect_url = f"{_get_app_url()}/dashboard"
+    clerk_org_id = await _get_or_create_clerk_org_id(invitation["organization_id"])
 
-    try:
-        await create_clerk_invitation(
-            email=invitation["email"],
-            redirect_url=redirect_url,
-            public_metadata={
-                "organization_id": invitation["organization_id"],
-                "role": invitation["role"],
-                "invitation_token": invitation["token"],
-            },
-        )
-    except HTTPException as e:
-        if e.status_code == 422 and "form_identifier_exists" in str(e.detail):
+    if clerk_org_id:
+        await revoke_clerk_org_invitations_for_email(clerk_org_id, invitation["email"])
+        try:
+            await create_clerk_org_invitation(
+                clerk_org_id=clerk_org_id,
+                email=invitation["email"],
+                redirect_url=redirect_url,
+            )
+        except HTTPException as e:
+            detail = str(e.detail)
+            if not (
+                e.status_code == 422
+                and ("form_identifier_exists" in detail or "already" in detail.lower())
+            ):
+                raise e
+            print(f"User {invitation['email']} already exists or is a member.")
+    else:
+        # Fallback to generic invitation
+        await revoke_clerk_invitations_for_email(invitation["email"])
+        try:
+            await create_clerk_invitation(
+                email=invitation["email"],
+                redirect_url=redirect_url,
+                public_metadata={
+                    "organization_id": invitation["organization_id"],
+                    "role": invitation["role"],
+                    "invitation_token": invitation["token"],
+                },
+            )
+        except HTTPException as e:
+            if not (e.status_code == 422 and "form_identifier_exists" in str(e.detail)):
+                raise e
             print(f"User {invitation['email']} already exists in Clerk.")
-        else:
-            raise e
 
     # Update timestamp
     now = datetime.utcnow()

--- a/apps/api/tests/auth/test_invitation_service.py
+++ b/apps/api/tests/auth/test_invitation_service.py
@@ -20,7 +20,16 @@ from apps.api.tests.conftest import (
     mock_users_collection,
 )
 
+# Patch _get_or_create_clerk_org_id to return None (fallback to generic invitation)
+# for tests that don't need org invitation behavior.
+MOCK_NO_CLERK_ORG = patch(
+    "apps.api.src.auth.service._get_or_create_clerk_org_id",
+    new_callable=AsyncMock,
+    return_value=None,
+)
 
+
+@MOCK_NO_CLERK_ORG
 @patch(
     "apps.api.src.auth.service.revoke_clerk_invitations_for_email",
     new_callable=AsyncMock,
@@ -28,7 +37,9 @@ from apps.api.tests.conftest import (
 class TestCreateInvitation:
     @pytest.mark.asyncio
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_creates_invitation_successfully(self, mock_clerk, _mock_revoke):
+    async def test_creates_invitation_successfully(
+        self, mock_clerk, _mock_revoke, _mock_clerk_org
+    ):
         mock_clerk.return_value = {"id": "clerk_inv_1"}
         inv_id = ObjectId()
         mock_invitations_collection.find_one.return_value = None
@@ -47,13 +58,15 @@ class TestCreateInvitation:
         mock_clerk.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_rejects_invalid_email(self, _mock_revoke):
+    async def test_rejects_invalid_email(self, _mock_revoke, _mock_clerk_org):
         with pytest.raises(Exception, match="Invalid email address format"):
             await create_invitation("not-an-email", "org-1", "inviter-1", "MEMBER")
 
     @pytest.mark.asyncio
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_resends_duplicate_pending_invitation(self, mock_clerk, _mock_revoke):
+    async def test_resends_duplicate_pending_invitation(
+        self, mock_clerk, _mock_revoke, _mock_clerk_org
+    ):
         mock_clerk.return_value = {"id": "clerk_inv_2"}
         existing = {
             "_id": ObjectId(),
@@ -77,7 +90,9 @@ class TestCreateInvitation:
 
     @pytest.mark.asyncio
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_replaces_expired_invitation(self, mock_clerk, _mock_revoke):
+    async def test_replaces_expired_invitation(
+        self, mock_clerk, _mock_revoke, _mock_clerk_org
+    ):
         mock_clerk.return_value = {"id": "clerk_inv_1"}
         expired = {
             "_id": ObjectId(),
@@ -100,7 +115,9 @@ class TestCreateInvitation:
 
     @pytest.mark.asyncio
     @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_notifies_existing_clerk_user(self, mock_clerk, _mock_revoke):
+    async def test_notifies_existing_clerk_user(
+        self, mock_clerk, _mock_revoke, _mock_clerk_org
+    ):
         from fastapi import HTTPException
 
         mock_clerk.side_effect = HTTPException(
@@ -138,6 +155,71 @@ class TestCreateInvitation:
         assert result["email"] == "existing@example.com"
         # Notification should have been created
         mock_notifications_collection.insert_one.assert_called_once()
+
+
+@MOCK_NO_CLERK_ORG
+@patch(
+    "apps.api.src.auth.service.revoke_clerk_org_invitations_for_email",
+    new_callable=AsyncMock,
+)
+@patch(
+    "apps.api.src.auth.service.create_clerk_org_invitation",
+    new_callable=AsyncMock,
+)
+class TestCreateInvitationWithOrgInvitation:
+    """Tests for invitation creation using Clerk Organization invitations."""
+
+    @pytest.mark.asyncio
+    async def test_uses_clerk_org_invitation_when_available(
+        self, mock_org_inv, _mock_revoke_org, mock_clerk_org
+    ):
+        mock_clerk_org.return_value = "clerk_org_123"
+        mock_org_inv.return_value = {"id": "org_inv_1"}
+        inv_id = ObjectId()
+        mock_invitations_collection.find_one.return_value = None
+        mock_invitations_collection.insert_one.return_value = MagicMock(
+            inserted_id=inv_id
+        )
+
+        result = await create_invitation(
+            "user@example.com", "org-1", "inviter-1", "MEMBER"
+        )
+
+        assert result["email"] == "user@example.com"
+        mock_org_inv.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "apps.api.src.auth.service.revoke_clerk_invitations_for_email",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.api.src.auth.service.create_clerk_invitation",
+        new_callable=AsyncMock,
+    )
+    async def test_falls_back_to_generic_on_org_failure(
+        self,
+        mock_generic,
+        _mock_revoke_generic,
+        mock_org_inv,
+        _mock_revoke_org,
+        mock_clerk_org,
+    ):
+        mock_clerk_org.return_value = "clerk_org_123"
+        mock_org_inv.side_effect = Exception("Clerk org API error")
+        mock_generic.return_value = {"id": "generic_inv_1"}
+        inv_id = ObjectId()
+        mock_invitations_collection.find_one.return_value = None
+        mock_invitations_collection.insert_one.return_value = MagicMock(
+            inserted_id=inv_id
+        )
+
+        result = await create_invitation(
+            "user@example.com", "org-1", "inviter-1", "MEMBER"
+        )
+
+        assert result["email"] == "user@example.com"
+        mock_generic.assert_called_once()
 
 
 class TestAcceptInvitationById:
@@ -232,10 +314,15 @@ class TestAcceptInvitationById:
 class TestRevokeInvitation:
     @pytest.mark.asyncio
     @patch(
+        "apps.api.src.auth.service._get_or_create_clerk_org_id",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    @patch(
         "apps.api.src.auth.service.revoke_clerk_invitations_for_email",
         new_callable=AsyncMock,
     )
-    async def test_revokes_pending_invitation(self, mock_revoke_clerk):
+    async def test_revokes_pending_invitation(self, mock_revoke_clerk, _mock_clerk_org):
         inv_id = ObjectId()
         invitation = {
             "_id": inv_id,
@@ -275,11 +362,19 @@ class TestRevokeInvitation:
 class TestResendInvitation:
     @pytest.mark.asyncio
     @patch(
+        "apps.api.src.auth.service._get_or_create_clerk_org_id",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    @patch(
         "apps.api.src.auth.service.revoke_clerk_invitations_for_email",
         new_callable=AsyncMock,
     )
-    @patch("apps.api.src.auth.service.create_clerk_invitation", new_callable=AsyncMock)
-    async def test_resends_invitation(self, mock_clerk, _mock_revoke):
+    @patch(
+        "apps.api.src.auth.service.create_clerk_invitation",
+        new_callable=AsyncMock,
+    )
+    async def test_resends_invitation(self, mock_clerk, _mock_revoke, _mock_clerk_org):
         mock_clerk.return_value = {"id": "clerk_inv_1"}
         inv_id = ObjectId()
         invitation = {
@@ -301,6 +396,45 @@ class TestResendInvitation:
 
         assert result is not None
         mock_clerk.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "apps.api.src.auth.service._get_or_create_clerk_org_id",
+        new_callable=AsyncMock,
+        return_value="clerk_org_123",
+    )
+    @patch(
+        "apps.api.src.auth.service.revoke_clerk_org_invitations_for_email",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "apps.api.src.auth.service.create_clerk_org_invitation",
+        new_callable=AsyncMock,
+    )
+    async def test_resends_via_org_invitation(
+        self, mock_org_inv, _mock_revoke_org, _mock_clerk_org
+    ):
+        mock_org_inv.return_value = {"id": "org_inv_1"}
+        inv_id = ObjectId()
+        invitation = {
+            "_id": inv_id,
+            "email": "user@example.com",
+            "organization_id": "org-1",
+            "role": "MEMBER",
+            "token": "tok-123",
+            "accepted_at": None,
+            "method": "EMAIL",
+            "expires_at": datetime.utcnow() + timedelta(days=3),
+            "created_at": datetime.utcnow(),
+            "inviter_id": "inviter-1",
+        }
+        mock_invitations_collection.find_one.return_value = invitation
+        mock_invitations_collection.find_one_and_update.return_value = invitation
+
+        result = await resend_invitation(str(inv_id))
+
+        assert result is not None
+        mock_org_inv.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_raises_when_not_found(self):


### PR DESCRIPTION
## Summary
- Invitation emails now show the actual organization name (e.g., "Edificio QA Test") instead of "Personal workspace"
- Lazily creates Clerk organizations that mirror app organizations, storing `clerk_org_id` on the MongoDB org document
- Falls back to generic Clerk invitations if org invitation creation fails

## Details
The code was using Clerk's generic `/v1/invitations` API, which sends emails branded with the Clerk app name ("Personal workspace"). This switches to Clerk Organization invitations (`/v1/organizations/{id}/invitations`), which include the organization name in the email.

New functions in `clerk_utils.py`:
- `create_clerk_organization()` — creates a Clerk org
- `create_clerk_org_invitation()` — creates an org-scoped invitation
- `revoke_clerk_org_invitations_for_email()` — revokes pending org invitations

The service layer (`_send_clerk_invitation`) tries the org invitation path first and gracefully falls back to generic invitations on failure.

Closes #139

## Test plan
- [x] All 161 backend tests pass (including 19 invitation-specific tests)
- [x] New tests for org invitation path and fallback behavior
- [x] Linting passes (black, flake8)
- [ ] Manual: Send invitation → verify email shows org name instead of "Personal workspace"
- [ ] Manual: Resend invitation → verify same behavior
- [ ] Manual: Revoke invitation → verify no stale Clerk invitations remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)