### PR TITLE
fix: show pending invitation immediately after sending

### DIFF
--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -27,6 +27,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import PendingInvitationsTable from '@/components/settings/PendingInvitationsTable';
+import type { Invitation } from '@/lib/queries/invitation';
 
 const ME_QUERY = `
   query Me {
@@ -49,6 +50,10 @@ const CREATE_INVITATION = `
     createInvitation(email: $email, organizationId: $organizationId, role: $role) {
       id
       email
+      role
+      method
+      expiresAt
+      createdAt
     }
   }
 `;
@@ -270,6 +275,7 @@ function MembersTab({
   const [inviteSuccess, setInviteSuccess] = useState(false);
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [inviteRefresh, setInviteRefresh] = useState(0);
+  const [lastCreatedInvitation, setLastCreatedInvitation] = useState<Invitation | null>(null);
 
   const filteredMembers = members.filter((m) => {
     const q = search.toLowerCase();
@@ -290,9 +296,12 @@ function MembersTab({
     try {
       const token = await getAuthToken();
       const client = getApiClient(token);
-      await client.request(CREATE_INVITATION, { email, organizationId, role });
+      const result = await client.request<{ createInvitation: Invitation }>(
+        CREATE_INVITATION, { email, organizationId, role }
+      );
       setEmail('');
       setInviteSuccess(true);
+      setLastCreatedInvitation(result.createInvitation);
       setInviteRefresh((n) => n + 1);
       setTimeout(() => setInviteSuccess(false), 3000);
     } catch (err: unknown) {
@@ -499,6 +508,7 @@ function MembersTab({
           getAuthToken={getAuthToken}
           t={t}
           refreshTrigger={inviteRefresh}
+          lastCreatedInvitation={lastCreatedInvitation}
         />
       )}
     </div>

--- a/apps/web/components/settings/PendingInvitationsTable.tsx
+++ b/apps/web/components/settings/PendingInvitationsTable.tsx
@@ -18,6 +18,7 @@ type PendingInvitationsTableProps = {
   getAuthToken: () => Promise<string | null>;
   t: (key: string, values?: Record<string, string | number>) => string;
   refreshTrigger?: number;
+  lastCreatedInvitation?: Invitation | null;
 };
 
 export default function PendingInvitationsTable({
@@ -25,6 +26,7 @@ export default function PendingInvitationsTable({
   getAuthToken,
   t,
   refreshTrigger,
+  lastCreatedInvitation,
 }: PendingInvitationsTableProps) {
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -49,6 +51,16 @@ export default function PendingInvitationsTable({
   useEffect(() => {
     fetchInvitations();
   }, [fetchInvitations, refreshTrigger]);
+
+  // Optimistically add newly created invitation to the list
+  useEffect(() => {
+    if (lastCreatedInvitation) {
+      setInvitations((prev) => {
+        if (prev.some((inv) => inv.id === lastCreatedInvitation.id)) return prev;
+        return [lastCreatedInvitation, ...prev];
+      });
+    }
+  }, [lastCreatedInvitation]);
 
   const handleRevoke = async (invitationId: string) => {
     setActionLoading(invitationId);


### PR DESCRIPTION
## Summary
- The pending invitations counter stayed at 0 after sending an invitation because the UI relied solely on a background refetch
- Now the `createInvitation` mutation returns full invitation data and it's optimistically added to the table immediately
- The background refetch still runs to sync with the server

## Details
- Expanded `CREATE_INVITATION` mutation return fields to include `role`, `method`, `expiresAt`, `createdAt`
- `MembersTab` captures the mutation result and passes it as `lastCreatedInvitation` prop to `PendingInvitationsTable`
- `PendingInvitationsTable` optimistically adds the new invitation to its local state (with dedup check)
- The existing `refreshTrigger` mechanism continues to sync the full list from the server

Closes #140

## Test plan
- [x] TypeScript type checking passes
- [x] Frontend tests pass (2 suites, 12 tests)
- [x] Backend invitation tests pass (16 tests)
- [ ] Manual: send invitation, verify counter updates to 1 immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)