### PR TITLE
fix: add visible ring to user avatar for all users

### DIFF
--- a/apps/web/components/dashboard/Sidebar.tsx
+++ b/apps/web/components/dashboard/Sidebar.tsx
@@ -74,7 +74,7 @@ function TopBar({ collapsed }: { collapsed: boolean }) {
       <NotificationBell />
       <UserButton
         appearance={{
-          elements: { avatarBox: 'w-8 h-8' },
+          elements: { avatarBox: 'w-8 h-8 ring-2 ring-border' },
         }}
       />
     </header>
@@ -184,7 +184,7 @@ function SidebarNav({
           <div className="flex items-center gap-3 px-3 py-3 mt-2 rounded-lg bg-sidebar-accent/50">
             <UserButton
               appearance={{
-                elements: { avatarBox: 'w-8 h-8' },
+                elements: { avatarBox: 'w-8 h-8 ring-2 ring-border' },
               }}
             />
             <div className="min-w-0 flex-1">

--- a/apps/web/components/landing/Header.tsx
+++ b/apps/web/components/landing/Header.tsx
@@ -53,7 +53,7 @@ export function Header() {
                   {t('dashboard')}
                 </Button>
               </Link>
-              <UserButton afterSignOutUrl="/" />
+              <UserButton afterSignOutUrl="/" appearance={{ elements: { avatarBox: 'ring-2 ring-border' } }} />
             </SignedIn>
           </div>
 
@@ -95,7 +95,7 @@ export function Header() {
                       {t('dashboard')}
                     </Button>
                   </Link>
-                  <UserButton afterSignOutUrl="/" />
+                  <UserButton afterSignOutUrl="/" appearance={{ elements: { avatarBox: 'ring-2 ring-border' } }} />
                 </SignedIn>
               </div>
             </nav>


### PR DESCRIPTION
## Summary
- Clerk's default avatar (gray silhouette) was hard to spot for invited users without a profile picture
- Added `ring-2 ring-border` to all `UserButton` avatar boxes (dashboard top bar, mobile drawer, landing page)
- Combined with #141's profile sync fix, invited users now have better name/avatar visibility

## Details
The `UserButton` from Clerk always renders, but its default state (no avatar, no name for initials) produces a subtle gray icon that blends with light backgrounds. Adding a border ring ensures the avatar area is always visible regardless of profile state.

Closes #144

## Test plan
- [x] TypeScript type checking passes
- [ ] Manual: verify avatar ring is visible for users with and without profile pictures

🤖 Generated with [Claude Code](https://claude.com/claude-code)