### PR TITLE
fix: show all bulk-added properties in onboarding wizard

### DIFF
--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -68,7 +68,7 @@ export default function OnboardingPage() {
       name: name.trim(),
     });
 
-    setHouses([...houses, { id: data.createHouse.id, name: data.createHouse.name }]);
+    setHouses((prev) => [...prev, { id: data.createHouse.id, name: data.createHouse.name }]);
   };
 
   const handleAddSingleHouse = async (e: FormEvent) => {


### PR DESCRIPTION
## Summary
- Bulk add in onboarding Step 2 only showed the last property due to a React stale closure bug
- Changed `setHouses([...houses, newHouse])` to `setHouses(prev => [...prev, newHouse])`

## Details
The `handleBulkAdd` loop called `handleAddHouse` sequentially with `await`. Each call used `setHouses([...houses, newHouse])` where `houses` was captured once at the start of the async function. Since React batches state updates, each iteration saw the same stale `houses` array and overwrote the previous addition. Only the last property survived.

The functional updater form `setHouses(prev => [...prev, newHouse])` ensures each iteration appends to the actual latest state.

Closes #145

## Test plan
- [x] TypeScript type checking passes
- [ ] Manual: bulk add "Apto 1-5", verify all 5 appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)