### PR TITLE
fix: correct singular/plural grammar for selected proposals count

### DIFF
--- a/apps/web/app/dashboard/vote/new/page.tsx
+++ b/apps/web/app/dashboard/vote/new/page.tsx
@@ -233,7 +233,9 @@ export default function NewVotingSessionPage() {
               {selectedIds.size !== 1
                 ? t('common.proposals')
                 : t('common.proposal')}{' '}
-              {t('voting.selected')}
+              {selectedIds.size !== 1
+                ? t('voting.selectedPlural')
+                : t('voting.selectedSingular')}
             </p>
           )}
         </div>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -521,6 +521,8 @@
       "proposalsToVote": "Proposals to Vote On * (select from VOTING status proposals)",
       "noVotingProposals": "No proposals in VOTING status. Move proposals to VOTING first.",
       "selected": "selected",
+      "selectedSingular": "selected",
+      "selectedPlural": "selected",
       "failedToLoadProposals": "Failed to load proposals",
       "createSession": "Create Session",
       "failedToCreateSession": "Failed to create voting session"

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -521,6 +521,8 @@
       "proposalsToVote": "Propuestas a votar * (seleccioná de las propuestas en estado VOTACIÓN)",
       "noVotingProposals": "No hay propuestas en estado VOTACIÓN. Pasá propuestas a VOTACIÓN primero.",
       "selected": "seleccionadas",
+      "selectedSingular": "seleccionada",
+      "selectedPlural": "seleccionadas",
       "failedToLoadProposals": "No se pudieron cargar las propuestas",
       "createSession": "Crear sesión",
       "failedToCreateSession": "No se pudo crear la sesión de votación"


### PR DESCRIPTION
## Summary
- Use separate `selectedSingular` / `selectedPlural` translation keys for the proposal count text
- Fixes "1 propuesta seleccionadas" → "1 propuesta seleccionada" (singular)
- Added keys to both `es.json` and `en.json`

Closes #147

## Test plan
- [x] TypeScript type check passes
- [ ] Verify "1 propuesta seleccionada" displays correctly when 1 proposal selected
- [ ] Verify "2 propuestas seleccionadas" displays correctly when 2+ proposals selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)