### PR TITLE
fix: replace hardcoded strings in committee page with i18n

### DIFF
--- a/apps/web/app/dashboard/committee/page.tsx
+++ b/apps/web/app/dashboard/committee/page.tsx
@@ -106,7 +106,7 @@ export default function CommitteePage() {
       );
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : 'Failed to update role.';
+        err instanceof Error ? err.message : t('committee.failedToUpdateRole');
       alert(message);
     } finally {
       setUpdatingId(null);
@@ -128,7 +128,7 @@ export default function CommitteePage() {
   if (error) {
     return (
       <ErrorState
-        title="Could not load committee"
+        title={t('committee.couldNotLoad')}
         message={error}
         onRetry={() => window.location.reload()}
       />
@@ -261,14 +261,14 @@ function MemberRow({
         )}
       </div>
       <div className="flex items-center gap-2">
-        <Badge variant={roleBadgeVariant(member.role)}>{member.role}</Badge>
+        <Badge variant={roleBadgeVariant(member.role)}>{t(`labels.roles.${member.role.toLowerCase()}`)}</Badge>
         {isAdmin && (
           <select
             className="text-xs border rounded px-2 py-1 bg-background"
             value={member.role}
             onChange={(e) => onRoleChange(member.id, e.target.value)}
             disabled={isUpdating}
-            aria-label={`Change role for ${displayName}`}
+            aria-label={t('committee.changeRoleFor', { name: displayName })}
           >
             <option value="ADMIN">{t('labels.roles.admin')}</option>
             <option value="RESIDENT">{t('labels.roles.resident')}</option>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -357,7 +357,10 @@
       "boardMembers": "Board Members (Admins)",
       "noAdmins": "No administrators found.",
       "membersAndResidents": "Members & Residents",
-      "noOtherMembers": "No other members yet. Invite users from the Settings page."
+      "noOtherMembers": "No other members yet. Invite users from the Settings page.",
+      "couldNotLoad": "Could not load committee",
+      "failedToUpdateRole": "Failed to update role.",
+      "changeRoleFor": "Change role for {name}"
     },
     "proposals": {
       "title": "Proposals",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -357,7 +357,10 @@
       "boardMembers": "Directivos (Admins)",
       "noAdmins": "No se encontraron administradores.",
       "membersAndResidents": "Miembros y residentes",
-      "noOtherMembers": "Aún no hay otros miembros. Invitá usuarios desde la página de Configuración."
+      "noOtherMembers": "Aún no hay otros miembros. Invitá usuarios desde la página de Configuración.",
+      "couldNotLoad": "No se pudo cargar el comité",
+      "failedToUpdateRole": "No se pudo actualizar el rol.",
+      "changeRoleFor": "Cambiar rol de {name}"
     },
     "proposals": {
       "title": "Propuestas",


### PR DESCRIPTION
## Summary
- Replace 3 hardcoded English strings with proper i18n translation keys
- Show translated role labels in badges instead of raw enum values (ADMIN → Admin/Administrador)
- Added `couldNotLoad`, `failedToUpdateRole`, `changeRoleFor` keys to both `es.json` and `en.json`

Closes #148

## Test plan
- [x] TypeScript type check passes
- [ ] Committee page loads without errors
- [ ] Role badges show translated labels
- [ ] Error states show localized messages
- [ ] Role change dropdown aria-label is localized

🤖 Generated with [Claude Code](https://claude.com/claude-code)