### PR TITLE
feat: rename Comité to Administración/Management

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -233,7 +233,7 @@
     "sidebar": {
       "overview": "Overview",
       "properties": "Properties",
-      "committee": "Committee",
+      "committee": "Management",
       "proposals": "Proposals",
       "voting": "Voting",
       "reports": "Reports",
@@ -350,7 +350,7 @@
       "voterUpdated": "Designated voter updated successfully."
     },
     "committee": {
-      "title": "Committee",
+      "title": "Management",
       "subtitle": "Board members & residents of {orgName}",
       "notInOrg": "You are not part of any organization.",
       "failedToLoad": "Failed to load committee members.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -233,7 +233,7 @@
     "sidebar": {
       "overview": "Inicio",
       "properties": "Propiedades",
-      "committee": "Comité",
+      "committee": "Administración",
       "proposals": "Propuestas",
       "voting": "Votaciones",
       "reports": "Reportes",
@@ -350,7 +350,7 @@
       "voterUpdated": "Votante designado actualizado correctamente."
     },
     "committee": {
-      "title": "Comité",
+      "title": "Administración",
       "subtitle": "Directivos y residentes de {orgName}",
       "notInOrg": "No sos parte de ninguna organización.",
       "failedToLoad": "No se pudieron cargar los miembros del comité.",


### PR DESCRIPTION
## Summary
- Sidebar label: "Comité" → "Administración" (ES), "Committee" → "Management" (EN)
- Page title updated to match in both locales
- Route `/dashboard/committee` kept as-is (internal path)

Closes #149

## Test plan
- [x] TypeScript type check passes
- [ ] Sidebar shows "Administración" in Spanish, "Management" in English
- [ ] Committee page title matches the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)