### PR TITLE
fix: disable GraphQL introspection on production

### DIFF
--- a/apps/api/schema.py
+++ b/apps/api/schema.py
@@ -1,4 +1,8 @@
+import os
+
 import strawberry
+from graphql.validation import NoSchemaIntrospectionCustomRule
+from strawberry.extensions import AddValidationRules
 
 from .schemas.analytics import AnalyticsQueries
 from .schemas.announcement import AnnouncementMutations, AnnouncementQueries
@@ -54,4 +58,8 @@ class Mutation(
     pass
 
 
-schema = strawberry.Schema(query=Query, mutation=Mutation)
+_extensions = []
+if os.environ.get("VERCEL_ENV") == "production":
+    _extensions.append(AddValidationRules([NoSchemaIntrospectionCustomRule]))
+
+schema = strawberry.Schema(query=Query, mutation=Mutation, extensions=_extensions)


### PR DESCRIPTION
## Summary
- Disable GraphQL schema introspection when `VERCEL_ENV=production`
- Uses graphql-core's `NoSchemaIntrospectionCustomRule` via Strawberry's `AddValidationRules` extension
- Introspection remains available in development/preview environments

Closes #151

## Test plan
- [x] All 154 backend tests pass
- [x] Black formatting passes
- [ ] After deploy: `curl -X POST https://condo-agora.vercel.app/api/graphql -H "Content-Type: application/json" -d '{"query": "{ __schema { types { name } } }"}' ` should return an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)