### PR TITLE
fix: enforce RBAC in organization members query and participation report

### DIFF
--- a/apps/api/resolvers/analytics.py
+++ b/apps/api/resolvers/analytics.py
@@ -63,14 +63,15 @@ async def resolve_participation_report(
     if not user:
         raise Exception("Authentication required")
 
-    report = await service_participation(session_id)
-
-    # Need to check admin access
+    # Check admin access before fetching report
     from ..src.voting.service import get_voting_session
 
     session = await get_voting_session(session_id)
-    if session:
-        await require_org_admin(user, session["organization_id"])
+    if not session:
+        raise Exception("Voting session not found")
+    await require_org_admin(user, session["organization_id"])
+
+    report = await service_participation(session_id)
 
     return ParticipationReport(
         session_id=report["session_id"],

--- a/apps/api/resolvers/auth.py
+++ b/apps/api/resolvers/auth.py
@@ -12,7 +12,7 @@ from ..graphql_types.auth import (
     User,
 )
 from ..graphql_types.house import House
-from ..src.auth.permissions import require_org_admin
+from ..src.auth.permissions import require_org_admin, require_org_member
 from ..src.auth.service import accept_invitation_by_id as service_accept_invitation
 from ..src.auth.service import create_invitation as service_create_invitation
 from ..src.auth.service import create_organization as service_create_org
@@ -222,11 +222,12 @@ def _mongo_member_to_member_with_user(m: dict) -> MemberWithUser:
 async def resolve_organization_members(
     info: strawberry.types.Info, organization_id: str
 ) -> List[MemberWithUser]:
-    """Resolver for listing all members of an organization."""
+    """Resolver for listing all members of an organization. MEMBER only."""
     user = info.context.get("user")
     if not user:
         raise Exception("Authentication required")
 
+    await require_org_member(user, organization_id)
     members = await service_get_members(organization_id)
     return [_mongo_member_to_member_with_user(m) for m in members]
 


### PR DESCRIPTION
## Summary
- **Organization members query**: Add `require_org_member` check — any authenticated user could previously list members of any organization
- **Participation report**: Validate admin permissions BEFORE fetching data, and properly reject when session doesn't exist (was skipping auth check entirely)

Full RBAC audit of 49 mutations confirmed all others are properly secured.

Closes #152

## Test plan
- [x] All 154 backend tests pass
- [x] Black formatting passes
- [ ] Verify non-member cannot query organization members
- [ ] Verify non-admin cannot access participation report

🤖 Generated with [Claude Code](https://claude.com/claude-code)