### PR TITLE
fix: improve mobile responsiveness in voting pages

### DIFF
--- a/apps/web/app/dashboard/vote/[sessionId]/page.tsx
+++ b/apps/web/app/dashboard/vote/[sessionId]/page.tsx
@@ -233,7 +233,7 @@ export default function VotingSessionPage() {
   const isClosed = session.status === 'CLOSED';
 
   return (
-    <div className="p-8 max-w-2xl mx-auto">
+    <div className="p-4 sm:p-8 max-w-2xl mx-auto">
       <Breadcrumb
         items={[
           { label: t('voting.breadcrumb'), href: '/dashboard/vote' },

--- a/apps/web/app/dashboard/vote/new/page.tsx
+++ b/apps/web/app/dashboard/vote/new/page.tsx
@@ -114,7 +114,7 @@ export default function NewVotingSessionPage() {
 
   if (loading) {
     return (
-      <div className="p-8">
+      <div className="p-4 sm:p-8">
         <div className="animate-pulse space-y-4">
           {[1, 2].map((i) => (
             <div key={i} className="h-16 bg-gray-100 rounded-lg" />
@@ -125,7 +125,7 @@ export default function NewVotingSessionPage() {
   }
 
   return (
-    <div className="p-8 max-w-2xl mx-auto">
+    <div className="p-4 sm:p-8 max-w-2xl mx-auto">
       <Breadcrumb
         items={[
           { label: t('voting.breadcrumb'), href: '/dashboard/vote' },
@@ -162,7 +162,7 @@ export default function NewVotingSessionPage() {
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label
               className="block text-sm font-medium mb-1"


### PR DESCRIPTION
## Summary
- Date inputs in new voting session form now stack vertically on mobile
- Reduced padding on small screens (p-4 → p-8 at sm breakpoint) in voting pages

Full responsive audit confirmed the app is well-designed overall — sidebar has proper hamburger behavior, tables have column hiding and horizontal scroll, all forms use w-full inputs, and grids use responsive breakpoints.

Closes #153

## Test plan
- [x] TypeScript type check passes
- [ ] Verify voting form date inputs stack on mobile (< 640px)
- [ ] Verify voting pages have adequate padding on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)