### PR TITLE
perf: fix N+1 query in house listing and add missing index

### DIFF
--- a/apps/api/database.py
+++ b/apps/api/database.py
@@ -89,6 +89,7 @@ class MongoDB:
         )
         await self.db.organization_members.create_index("user_id")
         await self.db.organization_members.create_index("organization_id")
+        await self.db.organization_members.create_index("house_id")
 
         # Invitations collection indexes
         await self.db.invitations.create_index("token", unique=True)
@@ -97,9 +98,6 @@ class MongoDB:
 
         # Houses collection indexes
         await self.db.houses.create_index("organization_id")
-
-        # Notes collection indexes
-        await self.db.notes.create_index("created_at")
 
         # Proposals collection indexes
         await self.db.proposals.create_index("organization_id")

--- a/apps/api/src/house/service.py
+++ b/apps/api/src/house/service.py
@@ -19,17 +19,23 @@ async def get_houses(organization_id: str) -> List:
     cursor = db.db.houses.find({"organization_id": organization_id}).sort(
         "created_at", 1
     )
-
     async for house in cursor:
-        # Fetch residents for this house
-        residents = []
-        residents_cursor = db.db.organization_members.find(
-            {"house_id": str(house["_id"])}
-        )
-        async for resident in residents_cursor:
-            residents.append(resident)
-        house["residents"] = residents
         houses.append(house)
+
+    if not houses:
+        return houses
+
+    # Batch-fetch all residents for this organization's houses in one query
+    house_ids = [str(h["_id"]) for h in houses]
+    residents_by_house: dict = {hid: [] for hid in house_ids}
+    residents_cursor = db.db.organization_members.find({"house_id": {"$in": house_ids}})
+    async for resident in residents_cursor:
+        hid = resident.get("house_id")
+        if hid in residents_by_house:
+            residents_by_house[hid].append(resident)
+
+    for house in houses:
+        house["residents"] = residents_by_house.get(str(house["_id"]), [])
 
     return houses
 


### PR DESCRIPTION
## Summary
- **N+1 fix**: House listing now batch-fetches all residents in 1 query instead of 1 per house (100 houses: 101 queries → 2 queries)
- **New index**: Added `house_id` index on `organization_members` for fast resident lookups
- Removed unused notes collection index

Performance audit also confirmed: all list endpoints should eventually add pagination, but the N+1 was the most critical bottleneck.

Closes #155

## Test plan
- [x] All 154 backend tests pass
- [x] Black formatting passes
- [ ] Verify house listing still shows residents correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)