### PR TITLE
design: introduce DM Serif Display font for headlines

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -204,7 +204,7 @@ export default function DashboardPage() {
     <div className="p-6 lg:p-8 max-w-6xl mx-auto space-y-8">
       {/* Header */}
       <div>
-        <h1 className="text-2xl lg:text-3xl font-bold">
+        <h1 className="text-2xl lg:text-3xl font-bold font-display">
           {t('overview.welcomeBack', { name: user?.firstName || user?.primaryEmailAddress?.emailAddress?.split('@')[0] || 'User' })}
         </h1>
         {data?.organizationName && (

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -124,14 +124,17 @@
 
   .heading-xl {
     @apply text-5xl lg:text-7xl font-bold tracking-tight leading-[1.1];
+    font-family: 'DM Serif Display', Georgia, serif;
   }
 
   .heading-lg {
     @apply text-3xl lg:text-5xl font-bold tracking-tight;
+    font-family: 'DM Serif Display', Georgia, serif;
   }
 
   .heading-md {
     @apply text-xl lg:text-2xl font-semibold;
+    font-family: 'DM Serif Display', Georgia, serif;
   }
 
   .text-body {

--- a/apps/web/components/landing/HeroSection.tsx
+++ b/apps/web/components/landing/HeroSection.tsx
@@ -56,7 +56,7 @@ export function HeroSection() {
                   )}
                   <Icon className="w-5 h-5 text-primary" />
                   <div className="text-left">
-                    <p className="text-xl font-bold text-foreground">{stat.value}</p>
+                    <p className="text-xl font-bold text-foreground font-display">{stat.value}</p>
                     <p className="text-xs text-muted-foreground">{t(`stats.${stat.labelKey}`)}</p>
                   </div>
                 </div>

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -16,6 +16,10 @@ module.exports = {
       },
     },
     extend: {
+      fontFamily: {
+        display: ["'DM Serif Display'", "Georgia", "serif"],
+        body: ["'Plus Jakarta Sans'", "system-ui", "sans-serif"],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- Add DM Serif Display as display/headline font for "Civic Warmth" aesthetic
- Keep Plus Jakarta Sans for body text
- Heading utility classes (heading-xl, heading-lg, heading-md) now use serif font
- Hero stats and dashboard welcome heading use display font
- Added `font-display` and `font-body` to Tailwind config for reuse

Closes #156

## Test plan
- [x] TypeScript type check passes
- [ ] Verify serif font renders on landing page headlines
- [ ] Verify dashboard welcome uses serif font
- [ ] Verify body text still uses Plus Jakarta Sans
- [ ] Test with Spanish and English locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)