### PR TITLE
fix: handle null email crash on login

### DIFF
--- a/apps/web/app/dashboard/committee/page.tsx
+++ b/apps/web/app/dashboard/committee/page.tsx
@@ -137,7 +137,7 @@ export default function CommitteePage() {
     if (m.firstName || m.lastName) {
       return [m.firstName, m.lastName].filter(Boolean).join(' ');
     }
-    return m.email;
+    return m.email ?? '';
   };
 
   const roleBadgeVariant = (role: string) => {
@@ -248,7 +248,7 @@ function MemberRow({
     <div className="flex items-center justify-between p-3 rounded-lg border">
       <div>
         <p className="text-sm font-medium">{displayName}</p>
-        <p className="text-xs text-muted-foreground">{member.email}</p>
+        <p className="text-xs text-muted-foreground">{member.email ?? ''}</p>
         {member.houseName && (
           <p className="text-xs text-muted-foreground mt-0.5">
             {t('overview.unitLabel', { name: member.houseName })}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -307,7 +307,7 @@ export default function DashboardPage() {
                   const name =
                     member.firstName || member.lastName
                       ? [member.firstName, member.lastName].filter(Boolean).join(' ')
-                      : member.email;
+                      : member.email ?? '';
                   return (
                     <div
                       key={member.id}
@@ -316,7 +316,7 @@ export default function DashboardPage() {
                       <div className="flex items-center gap-3 min-w-0">
                         <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
                           <span className="text-xs font-semibold text-primary">
-                            {(member.firstName?.[0] || member.email[0]).toUpperCase()}
+                            {(member.firstName?.[0] || member.email?.[0] || '?').toUpperCase()}
                           </span>
                         </div>
                         <div className="min-w-0">

--- a/apps/web/app/dashboard/properties/[id]/page.tsx
+++ b/apps/web/app/dashboard/properties/[id]/page.tsx
@@ -400,7 +400,7 @@ function ResidentsTab({
     const member = memberMap.get(userId);
     if (!member) return { name: t('common.member'), detail: userId.slice(0, 12) + '...' };
     const name = [member.firstName, member.lastName].filter(Boolean).join(' ') || t('common.member');
-    return { name, detail: member.email };
+    return { name, detail: member.email ?? '' };
   };
 
   const handleRemove = async (userId: string) => {

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -274,7 +274,7 @@ function MembersTab({
   const filteredMembers = members.filter((m) => {
     const q = search.toLowerCase();
     return (
-      m.email.toLowerCase().includes(q) ||
+      (m.email ?? '').toLowerCase().includes(q) ||
       m.firstName?.toLowerCase().includes(q) ||
       m.lastName?.toLowerCase().includes(q) ||
       m.role.toLowerCase().includes(q)
@@ -313,7 +313,7 @@ function MembersTab({
   const handleRemoveMember = async (member: Member) => {
     const name = member.firstName || member.lastName
       ? [member.firstName, member.lastName].filter(Boolean).join(' ')
-      : member.email;
+      : member.email ?? '';
     if (!confirm(t('settings.removeMemberConfirm', { name }))) return;
 
     setRemovingId(member.id);
@@ -333,7 +333,7 @@ function MembersTab({
     if (m.firstName || m.lastName) {
       return [m.firstName, m.lastName].filter(Boolean).join(' ');
     }
-    return m.email;
+    return m.email ?? '';
   };
 
   return (
@@ -400,19 +400,19 @@ function MembersTab({
                         <div className="flex items-center gap-3">
                           <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
                             <span className="text-xs font-semibold text-primary">
-                              {(member.firstName?.[0] || member.email[0]).toUpperCase()}
+                              {(member.firstName?.[0] || member.email?.[0] || '?').toUpperCase()}
                             </span>
                           </div>
                           <div className="min-w-0">
                             <p className="text-sm font-medium truncate">{getMemberName(member)}</p>
                             <p className="text-xs text-muted-foreground truncate sm:hidden">
-                              {member.email}
+                              {member.email ?? ''}
                             </p>
                           </div>
                         </div>
                       </td>
                       <td className="px-4 py-3 text-sm text-muted-foreground hidden sm:table-cell">
-                        {member.email}
+                        {member.email ?? ''}
                       </td>
                       <td className="px-4 py-3">
                         <Badge

--- a/apps/web/app/dashboard/vote/[sessionId]/results/page.tsx
+++ b/apps/web/app/dashboard/vote/[sessionId]/results/page.tsx
@@ -69,7 +69,8 @@ export default function VotingResultsPage() {
 
   if (error || !results) return <ErrorState message={error || t('voting.noResults')} />;
 
-  const maxScore = Math.max(...results.proposalScores.map((p) => p.score), 1);
+  const scores = results.proposalScores ?? [];
+  const maxScore = Math.max(...scores.map((p) => p.score), 1);
 
   return (
     <div className="p-8 max-w-3xl mx-auto">
@@ -152,13 +153,13 @@ export default function VotingResultsPage() {
           {t('voting.proposalRankings')}
         </h2>
         <div className="space-y-3">
-          {results.proposalScores.map((ps) => (
+          {scores.map((ps) => (
             <ProposalResultCard key={ps.proposalId} ps={ps} maxScore={maxScore} t={t} />
           ))}
         </div>
       </div>
 
-      {results.proposalScores.length === 0 && (
+      {scores.length === 0 && (
         <div className="text-center py-12 text-muted-foreground">
           {t('voting.noVotesYet')}
         </div>

--- a/apps/web/lib/queries/members.ts
+++ b/apps/web/lib/queries/members.ts
@@ -35,7 +35,7 @@ export type Member = {
   organizationId: string;
   houseId: string | null;
   role: string;
-  email: string;
+  email: string | null;
   firstName: string | null;
   lastName: string | null;
   avatarUrl: string | null;


### PR DESCRIPTION
## Summary
- After `08e73d6` made `MemberWithUser.email` optional, `member.email[0]` crashes with `TypeError: Cannot read properties of null (reading '0')` when a member has no email
- Added null-safe access (`?.`, `?? ''`) across dashboard, settings, committee, properties, and voting results pages
- Updated `Member` type to reflect `email: string | null`

## Test plan
- [ ] Log in with a user whose member record has no email — verify no crash
- [ ] Verify dashboard, committee, settings, and property detail pages render members without email

🤖 Generated with [Claude Code](https://claude.com/claude-code)